### PR TITLE
fix: missing adapter names

### DIFF
--- a/src/handlers/multiAdapterHandlers.ts
+++ b/src/handlers/multiAdapterHandlers.ts
@@ -230,7 +230,7 @@ ponder.on(
     for (const adapter of adapters) {
       const contracts = Object.entries(currentChain.contracts);
       const [contractName = null] =
-        contracts.find(([_, contractAddress]) => contractAddress === adapter) ??
+        contracts.find(([_, contractAddress]) => contractAddress.toLowerCase() === adapter) ??
         [];
       const firstPart = contractName
         ? contractName.split(/(?=[A-Z])/)[0]


### PR DESCRIPTION
Fixes bug where due to ponder.sh breaking changes on address formatting, adapter names are wrongly set to null