### PR TITLE
fix: refine Invest and Redeem Orders

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+build
+coverage
+*.log
+pnpm-lock.yaml
+tsconfig.tsbuildinfo
+generated

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-jsdoc": "^56.1.2",
     "eslint-plugin-unused-imports": "^4.3.0",
     "husky": "^9.1.7",
+    "prettier": "^3.8.0",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      prettier:
+        specifier: ^3.8.0
+        version: 3.8.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2330,6 +2333,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.0:
+    resolution: {integrity: sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
@@ -5200,6 +5208,8 @@ snapshots:
       xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.0: {}
 
   process-warning@3.0.0: {}
 

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -433,6 +433,9 @@ const VaultDepositColumns = (t: PgColumnsBuilders) => ({
   assetsAmount: t.bigint().notNull(),
 
   ...defaultColumns(t),
+
+  epochIndex: t.integer(),
+
 });
 
 export const VaultDeposit = onchainTable(
@@ -448,6 +451,10 @@ export const VaultDepositRelations = relations(VaultDeposit, ({ one }) => ({
     fields: [VaultDeposit.tokenId, VaultDeposit.centrifugeId],
     references: [Vault.tokenId, Vault.centrifugeId],
   }),
+  investOrder: one(InvestOrder, {
+    fields: [VaultDeposit.tokenId, VaultDeposit.assetId, VaultDeposit.accountAddress, VaultDeposit.epochIndex],
+    references: [InvestOrder.tokenId, InvestOrder.assetId, InvestOrder.account, InvestOrder.index],
+  }),
 }));
 
 const InvestOrderColumns = (t: PgColumnsBuilders) => ({
@@ -457,13 +464,10 @@ const InvestOrderColumns = (t: PgColumnsBuilders) => ({
   account: t.hex().notNull(),
   index: t.integer().notNull(),
 
-  // VaultDeposit fields
-  vaultDepositCentrifugeId: t.text(),
-  vaultDepositTxHash: t.hex(),
-
   // Posted fields
   ...timestamperFields(t, "posted"),
-  postedAssetsAmount: t.bigint().default(0n),
+  pendingAssetsAmount: t.bigint().default(0n),
+  queuedAssetsAmount: t.bigint().default(0n),
 
   // Approved fields
   ...timestamperFields(t, "approved"),
@@ -495,7 +499,7 @@ export const InvestOrder = onchainTable(
   })
 );
 
-export const InvestOrderRelations = relations(InvestOrder, ({ one }) => ({
+export const InvestOrderRelations = relations(InvestOrder, ({ one, many }) => ({
   token: one(Token, {
     fields: [InvestOrder.tokenId],
     references: [Token.id],
@@ -504,9 +508,8 @@ export const InvestOrderRelations = relations(InvestOrder, ({ one }) => ({
     fields: [InvestOrder.assetId],
     references: [Asset.id],
   }),
-  vaultDeposit: one(VaultDeposit, {
-    fields: [InvestOrder.tokenId, InvestOrder.vaultDepositCentrifugeId, InvestOrder.assetId, InvestOrder.account, InvestOrder.vaultDepositTxHash],
-    references: [VaultDeposit.tokenId, VaultDeposit.centrifugeId, VaultDeposit.assetId, VaultDeposit.accountAddress, VaultDeposit.createdAtTxHash],
+  vaultDeposits: many(VaultDeposit, {
+    relationName: "vaultDeposit",
   }),
 }));
 
@@ -519,6 +522,8 @@ const VaultRedeemColumns = (t: PgColumnsBuilders) => ({
   sharesAmount: t.bigint().notNull(),
 
   ...defaultColumns(t),
+
+  epochIndex: t.integer(),
 });
 
 export const VaultRedeem = onchainTable(
@@ -539,6 +544,10 @@ export const VaultRedeemRelations = relations(VaultRedeem, ({ one }) => ({
     fields: [VaultRedeem.tokenId, VaultRedeem.centrifugeId],
     references: [Vault.tokenId, Vault.centrifugeId],
   }),
+  redeemOrder: one(RedeemOrder, {
+    fields: [VaultRedeem.tokenId, VaultRedeem.assetId, VaultRedeem.accountAddress, VaultRedeem.epochIndex],
+    references: [RedeemOrder.tokenId, RedeemOrder.assetId, RedeemOrder.account, RedeemOrder.index],
+  }),
 }));
 
 const RedeemOrderColumns = (t: PgColumnsBuilders) => ({
@@ -548,13 +557,10 @@ const RedeemOrderColumns = (t: PgColumnsBuilders) => ({
   account: t.hex().notNull(),
   index: t.integer().notNull(),
 
-  // VaultRedeem fields
-  vaultRedeemCentrifugeId: t.text(),
-  vaultRedeemTxHash: t.hex(),
-
   // Posted fields
   ...timestamperFields(t, "posted"),
-  postedSharesAmount: t.bigint().default(0n),
+  pendingSharesAmount: t.bigint().default(0n),
+  queuedSharesAmount: t.bigint().default(0n),
 
   // Approved fields
   ...timestamperFields(t, "approved"),
@@ -588,7 +594,7 @@ export const RedeemOrder = onchainTable(
   })
 );
 
-export const RedeemOrderRelations = relations(RedeemOrder, ({ one }) => ({
+export const RedeemOrderRelations = relations(RedeemOrder, ({ one, many }) => ({
   token: one(Token, {
     fields: [RedeemOrder.tokenId],
     references: [Token.id],
@@ -597,9 +603,8 @@ export const RedeemOrderRelations = relations(RedeemOrder, ({ one }) => ({
     fields: [RedeemOrder.assetId],
     references: [Asset.id],
   }),
-  vaultRedeem: one(VaultRedeem, {
-    fields: [RedeemOrder.tokenId, RedeemOrder.vaultRedeemCentrifugeId, RedeemOrder.assetId, RedeemOrder.account, RedeemOrder.vaultRedeemTxHash],
-    references: [VaultRedeem.tokenId, VaultRedeem.centrifugeId, VaultRedeem.assetId, VaultRedeem.accountAddress, VaultRedeem.createdAtTxHash],
+  vaultRedeem: many(VaultRedeem, {
+    relationName: "vaultRedeem",
   }),
 }));
 

--- a/src/services/InvestOrderService.ts
+++ b/src/services/InvestOrderService.ts
@@ -25,15 +25,17 @@ export class InvestOrderService extends mixinCommonStatics(
    * @returns The service instance for method chaining
    */
   public post(
-    postedAssetsAmount: bigint,
+    pendingAssetsAmount: bigint,
+    queuedAssetsAmount: bigint,
     event: Extract<Event, { transaction: any }>
   ) {
     serviceLog(
-      `Filling investOrder ${this.data.tokenId}-${this.data.assetId}-${this.data.account}-${this.data.index} with postedAssetsAmount: ${postedAssetsAmount}`
+      `Filling investOrder ${this.data.tokenId}-${this.data.assetId}-${this.data.account}-${this.data.index} with pendingAssetsAmount: ${pendingAssetsAmount}, queuedAssetsAmount: ${queuedAssetsAmount}`
     );
     this.data = {
       ...this.data,
-      postedAssetsAmount,
+      pendingAssetsAmount,
+      queuedAssetsAmount,
       ...timestamper("posted", event),
     };
     return this;
@@ -126,41 +128,13 @@ export class InvestOrderService extends mixinCommonStatics(
   }
 
   /**
-   * Checks if the invest order has a vault deposit.
-   *
-   * @returns True if the invest order has a vault deposit, false otherwise
-   */
-  public hasVaultDeposit() {
-    return (
-      !!this.data.vaultDepositCentrifugeId &&
-      !!this.data.vaultDepositTxHash
-    );
-  }
-
-  /**
-   * Sets the vault deposit for the invest order.
-   *
-   * @param vaultDepositCentrifugeId - The centrifuge ID
-   * @param vaultDepositTxHash - The transaction hash
-   * @returns The service instance for method chaining
-   */
-  public setVaultDeposit(vaultDepositCentrifugeId: string, vaultDepositTxHash: `0x${string}`) {
-    this.data = {
-      ...this.data,
-      vaultDepositCentrifugeId,
-      vaultDepositTxHash,
-    };
-    return this;
-  }
-
-  /**
    * Saves or clears the invest order.
    *
    * @param event - The event containing the block information
    * @returns The service instance for method chaining
    */
   public saveOrClear(event: Event) {
-    if(this.data.postedAssetsAmount === 0n) return this.delete();
+    if(this.data.pendingAssetsAmount === 0n) return this.delete();
     return this.save(event);
   }
 }

--- a/src/services/RedeemOrderService.ts
+++ b/src/services/RedeemOrderService.ts
@@ -24,13 +24,14 @@ export class RedeemOrderService extends mixinCommonStatics(
    * @param event - The event containing the block information
    * @returns The service instance for method chaining
    */
-  public post(postedSharesAmount: bigint, event: Extract<Event, { transaction: any }>) {
+  public post(pendingSharesAmount: bigint, queuedSharesAmount: bigint, event: Extract<Event, { transaction: any }>) {
     serviceLog(
-      `Filling redeemOrder ${this.data.tokenId}-${this.data.assetId}-${this.data.account}-${this.data.index} with postedSharesAmount: ${postedSharesAmount}`
+      `Filling redeemOrder ${this.data.tokenId}-${this.data.assetId}-${this.data.account}-${this.data.index} with pendingSharesAmount: ${pendingSharesAmount}`
     );
     this.data = {
       ...this.data,
-      postedSharesAmount,
+      pendingSharesAmount,
+      queuedSharesAmount,
       ...timestamper("posted", event),
     }
     return this;
@@ -121,41 +122,13 @@ export class RedeemOrderService extends mixinCommonStatics(
   }
 
   /**
-   * Checks if the redeem order has a vault redeem.
-   *
-   * @returns True if the redeem order has a vault redeem, false otherwise
-   */
-  public hasVaultRedeem() {
-    return (
-      !!this.data.vaultRedeemCentrifugeId &&
-      !!this.data.vaultRedeemTxHash
-    );
-  }
-
-  /**
-   * Sets the vault redeem for the redeem order.
-   *
-   * @param vaultRedeemCentrifugeId - The centrifuge ID
-   * @param vaultRedeemTxHash - The transaction hash
-   * @returns The service instance for method chaining
-   */
-  public setVaultRedeem(vaultRedeemCentrifugeId: string, vaultRedeemTxHash: `0x${string}`) {
-    this.data = {
-      ...this.data,
-      vaultRedeemCentrifugeId,
-      vaultRedeemTxHash,
-    };
-    return this;
-  }
-
-  /**
    * Saves or clears the redeem order.
    *
    * @param event - The event containing the block information
    * @returns The service instance for method chaining
    */
   public saveOrClear(event: Event) {
-    if(this.data.postedSharesAmount === 0n) return this.delete();
+    if(this.data.pendingSharesAmount === 0n) return this.delete();
     return this.save(event);
   }
 }

--- a/src/services/Service.ts
+++ b/src/services/Service.ts
@@ -12,6 +12,8 @@ import {
   inArray,
   lte,
   gte,
+  lt,
+  gt,
 } from "drizzle-orm";
 import { getTableConfig, type PgTableWithColumns } from "drizzle-orm/pg-core";
 import {
@@ -474,7 +476,11 @@ type ExtendedQuery<T> = {
 } & {
   [P in keyof T as `${string & P}_lte`]: T[P];
 } & {
+  [P in keyof T as `${string & P}_lt`]: T[P];
+} & {
   [P in keyof T as `${string & P}_gte`]: T[P];
+} & {
+  [P in keyof T as `${string & P}_gt`]: T[P];
 } & {
   _sort?: Array<{
     field: keyof T;
@@ -510,8 +516,12 @@ function queryToFilter<T extends OnchainTable>(
       return inArray(table[column.slice(0, -3) as keyof T], value);
     if (column.endsWith("_lte"))
       return lte(table[column.slice(0, -4) as keyof T], value);
+    if (column.endsWith("_lt"))
+      return lt(table[column.slice(0, -3) as keyof T], value);
     if (column.endsWith("_gte"))
       return gte(table[column.slice(0, -4) as keyof T], value);
+    if (column.endsWith("_gt"))
+      return gt(table[column.slice(0, -3) as keyof T], value);
     return eq(table[column as keyof T], value);
   });
   if (queries.length > 1) {

--- a/src/services/VaultDepositService.ts
+++ b/src/services/VaultDepositService.ts
@@ -1,5 +1,6 @@
 import { VaultDeposit } from "ponder:schema";
 import { Service, mixinCommonStatics } from "./Service";
+import { serviceLog } from "../helpers/logger";
 
 /**
  * Service class for managing VaultDeposit entities.
@@ -13,4 +14,15 @@ export class VaultDepositService extends mixinCommonStatics(
   Service<typeof VaultDeposit>,
   VaultDeposit,
   "VaultDeposit"
-) {}
+) {
+  /**
+   * Sets the epoch index for the vault deposit.
+   * @param epochIndex - The epoch index to set.
+   * @returns The service instance for method chaining.
+   */
+  public setEpochIndex(epochIndex: number) {
+    serviceLog(`Setting epoch index to ${epochIndex}`)
+    this.data.epochIndex = epochIndex;
+    return this;
+  }
+}

--- a/src/services/VaultRedeemService.ts
+++ b/src/services/VaultRedeemService.ts
@@ -1,5 +1,6 @@
 import { VaultRedeem } from "ponder:schema";
 import { Service, mixinCommonStatics } from "./Service";
+import { serviceLog } from "../helpers/logger";
 
 /**
  * Service class for managing VaultRedeem entities.
@@ -13,4 +14,15 @@ export class VaultRedeemService extends mixinCommonStatics(
   Service<typeof VaultRedeem>,
   VaultRedeem,
   "VaultRedeem"
-) {}
+) {
+  /**
+   * Sets the epoch index for the vault redeem.
+   * @param epochIndex - The epoch index to set.
+   * @returns The service instance for method chaining.
+   */
+  public setEpochIndex(epochIndex: number) {
+    serviceLog(`Setting epoch index to ${epochIndex}`)
+    this.data.epochIndex = epochIndex;
+    return this;
+  }
+}


### PR DESCRIPTION
# Refine Invest and Redeem Orders

## Overview
This PR refines the Invest and Redeem Orders implementation to accurately model the order lifecycle and improve traceability between vault operations and order processing. The changes ensure proper tracking of investor orders through their complete journey from initial deposit/redeem requests through approval, execution, and final settlement.

## Business Context

### Order Lifecycle
Invest and Redeem Orders represent investor requests that flow through multiple stages:
1. **Queued**: Amounts queued for the next epoch
2. **Pending**: Amounts pending approval in the current epoch
3. **Approved**: Amounts approved for execution
4. **Issued/Revoked**: Shares issued (for invests) or assets revoked (for redeems)
5. **Claimed**: Final settlement where investors claim their shares or assets

### Business Problem
Previously, the system had several issues:
- **Incomplete tracking**: Vault deposits/redeems weren't properly linked to their corresponding orders, making it difficult to trace the full lifecycle of investor transactions
- **Ambiguous state**: The distinction between queued and pending amounts wasn't clear, leading to confusion about order status
- **Data inconsistency**: Orders could exist with zero amounts, cluttering the database and making reporting inaccurate
- **Missing epoch context**: Vault operations couldn't be properly associated with the epoch in which they were processed

## Business Value

### 1. Complete Order Traceability
**Problem Solved**: Investors and operators can now trace a vault deposit or redeem request all the way through to its corresponding order in the batch request manager, and see how it was processed across epochs.

**How it works**:
- Vault deposits and redeems are now linked to their orders via `epochIndex`
- When a deposit/redeem request is made, the system automatically finds and links it to the corresponding order
- This enables full audit trails and better customer support

### 2. Accurate Order State Tracking
**Problem Solved**: Clear distinction between queued and pending amounts ensures accurate reporting and prevents confusion about what's actually being processed.

**How it works**:
- **Queued amounts**: Assets/shares queued for the next epoch (not yet being processed)
- **Pending amounts**: Assets/shares currently pending approval in the active epoch
- This separation allows for accurate reporting on what's in-flight vs. what's scheduled

### 3. Automatic Order Cleanup
**Problem Solved**: Orders with zero pending amounts are automatically removed, keeping the database clean and ensuring only active orders are tracked.

**Business Impact**:
- Cleaner data for reporting and analytics
- Reduced storage costs
- More accurate order counts and statuses

### 4. Proper Epoch-Based Processing
**Problem Solved**: Orders are now properly associated with epochs, enabling accurate tracking of when deposits/redeems were processed and in which batch.

**How it works**:
- Each vault deposit/redeem is linked to an order via `epochIndex`
- This allows operators to see which epoch a transaction belongs to
- Enables proper reconciliation between vault operations and batch processing

### 5. Support for Multiple Vault Operations per Order
**Problem Solved**: A single order can now be associated with multiple vault deposits/redeems, accurately reflecting the business reality where investors may make multiple deposits that get batched into a single order.

**Business Impact**:
- More accurate representation of the actual business flow
- Better support for complex investor scenarios
- Improved data integrity

## Technical Implementation

### Schema Changes
- Added `epochIndex` to `VaultDeposit` and `VaultRedeem` to link them with orders
- Renamed `postedAssetsAmount`/`postedSharesAmount` to `pendingAssetsAmount`/`pendingSharesAmount` for clarity
- Added `queuedAssetsAmount`/`queuedSharesAmount` to track amounts queued for future epochs
- Removed redundant linking fields that were causing data inconsistencies
- Updated relationships to support one-to-many (one order can have multiple vault operations)

### Service Enhancements
- **`saveOrClear()` method**: Automatically removes orders when they have zero pending amounts, keeping data clean
- **`setEpochIndex()` method**: Allows vault deposits/redeems to be linked to their orders after creation
- Improved method signatures to better reflect the order lifecycle stages

### Handler Improvements
- **Vault handlers**: Now automatically link deposits/redeems to existing orders when found
- **Batch request manager handlers**: Properly update orders with queued and pending amounts, and link vault operations
- **Claim handlers**: New handlers for processing final settlement of deposits and redeems

## Files Changed

- `.prettierignore` (new)
- `.prettierrc.json` (new)
- `package.json`
- `pnpm-lock.yaml`
- `ponder.schema.ts`
- `src/handlers/batchRequestManagerHandlers.ts`
- `src/handlers/vaultHandlers.ts`
- `src/services/InvestOrderService.ts`
- `src/services/RedeemOrderService.ts`
- `src/services/Service.ts`
- `src/services/VaultDepositService.ts`
- `src/services/VaultRedeemService.ts`

## Related Issues

Fixes #209
