### PR TITLE
feat: inprogress update of balance sheet managers

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -941,12 +941,19 @@ export const HoldingEscrowRelations = relations(HoldingEscrow, ({ one }) => ({
   }),
 }));
 
+export const PoolManagerCrosschainInProgressTypes = [`CanManage`, `CanNotManage`] as const;
+export const PoolManagerCrosschainInProgress = onchainEnum(
+  "pool_manager_crosschain_in_progress",
+  PoolManagerCrosschainInProgressTypes
+);
+
 const PoolManagerColumns = (t: PgColumnsBuilders) => ({
   address: t.hex().notNull(),
   centrifugeId: t.text().notNull(),
   poolId: t.bigint().notNull(),
   isHubManager: t.boolean().notNull().default(false),
   isBalancesheetManager: t.boolean().notNull().default(false),
+  crosschainInProgress: PoolManagerCrosschainInProgress("pool_manager_crosschain_in_progress"),
   ...defaultColumns(t),
 });
 

--- a/src/handlers/balanceSheetHandlers.ts
+++ b/src/handlers/balanceSheetHandlers.ts
@@ -110,17 +110,17 @@ multiMapper("balanceSheet:UpdateManager", async ({ event, context }) => {
 
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
 
-  const { who: manager, poolId, canManage } = event.args;
+  const { who: _manager, poolId, canManage } = event.args;
 
-  const account = (await AccountService.getOrInit(
+  const managerAddress = _manager.toLowerCase().substring(0, 42) as `0x${string}`;
+
+  const _account = (await AccountService.getOrInit(
     context,
     {
-      address: manager,
+      address: managerAddress,
     },
     event
   )) as AccountService;
-
-  const { address: managerAddress } = account.read();
 
   const poolManager = (await PoolManagerService.getOrInit(
     context,
@@ -129,8 +129,10 @@ multiMapper("balanceSheet:UpdateManager", async ({ event, context }) => {
       centrifugeId,
       poolId,
     },
-    event
+    event,
+    undefined,
+    true
   )) as PoolManagerService;
-  poolManager.setIsBalancesheetManager(canManage);
-  await poolManager.save(event);
+
+  await poolManager.setCrosschainInProgress().setIsBalancesheetManager(canManage).save(event);
 });

--- a/src/handlers/hubHandlers.ts
+++ b/src/handlers/hubHandlers.ts
@@ -1,6 +1,12 @@
 import { multiMapper } from "../helpers/multiMapper";
 import { logEvent, serviceError } from "../helpers/logger";
-import { WhitelistedInvestorService, TokenService, PoolSpokeBlockchainService } from "../services";
+import {
+  WhitelistedInvestorService,
+  TokenService,
+  PoolSpokeBlockchainService,
+  PoolManagerService,
+  AccountService,
+} from "../services";
 
 multiMapper("hub:NotifyPool", async ({ event, context }) => {
   logEvent(event, context, "hub:NotifyPool");
@@ -64,6 +70,30 @@ multiMapper("hub:UpdateRestriction", async ({ event, context }) => {
     default:
       break;
   }
+});
+
+multiMapper("hub:UpdateBalanceSheetManager", async ({ event, context }) => {
+  logEvent(event, context, "hub:UpdateBalanceSheetManager");
+  const { poolId, manager: _manager, canManage, centrifugeId: spokeCentrifugeId } = event.args;
+  const manager = _manager.toLowerCase().substring(0, 42) as `0x${string}`;
+
+  const _account = (await AccountService.getOrInit(
+    context,
+    {
+      address: manager,
+    },
+    event
+  )) as AccountService;
+
+  const poolManager = (await PoolManagerService.getOrInit(
+    context,
+    { poolId, centrifugeId: spokeCentrifugeId.toString(), address: manager },
+    event,
+    undefined,
+    true
+  )) as PoolManagerService;
+  poolManager.setCrosschainInProgress(canManage ? `CanManage` : `CanNotManage`);
+  await poolManager.save(event);
 });
 
 enum RestrictionType {

--- a/src/services/PoolManagerService.ts
+++ b/src/services/PoolManagerService.ts
@@ -1,5 +1,6 @@
-import { PoolManager } from "ponder:schema";
+import { PoolManager, PoolManagerCrosschainInProgressTypes } from "ponder:schema";
 import { Service, mixinCommonStatics } from "./Service";
+import { serviceLog } from "../helpers/logger";
 
 /**
  * Service class for managing PoolManager entities.
@@ -27,6 +28,7 @@ export class PoolManagerService extends mixinCommonStatics(
    * @returns The service instance for method chaining
    */
   public setIsHubManager(isHubManager: boolean) {
+    serviceLog(`Setting isHubManager to ${isHubManager}`);
     this.data.isHubManager = isHubManager;
     return this;
   }
@@ -38,7 +40,22 @@ export class PoolManagerService extends mixinCommonStatics(
    * @returns The service instance for method chaining
    */
   public setIsBalancesheetManager(isBalancesheetManager: boolean) {
+    serviceLog(`Setting isBalancesheetManager to ${isBalancesheetManager}`);
     this.data.isBalancesheetManager = isBalancesheetManager;
+    return this;
+  }
+
+  /**
+   * Sets the crosschain progress for the manager.
+   *
+   * @param crosschainProgress - The value to set for crosschainProgress
+   * @returns The service instance for method chaining
+   */
+  public setCrosschainInProgress(
+    crosschainInProgress?: (typeof PoolManagerCrosschainInProgressTypes)[number]
+  ) {
+    this.data.crosschainInProgress = crosschainInProgress ?? null;
+    serviceLog(`Setting crosschainInProgress to ${crosschainInProgress}`);
     return this;
   }
 }


### PR DESCRIPTION
Fixes #277

# Update of balance sheet managers (crosschain support)

## Summary

Adds crosschain-aware handling for balance sheet manager updates. pool managers track an optional crosschain-in-progress state.

## Changes

- **Schema** (`ponder.schema.ts`): New enum `PoolManagerCrosschainInProgress` (`CanManage` | `CanNotManage`) and `crosschainInProgress` column on `PoolManager`.
- **PoolManagerService**: New `setCrosschainInProgress()` (chainable, optional value); added logging in `setIsHubManager` and `setIsBalancesheetManager`.
- **balanceSheetHandlers**: Normalize manager address; use `getOrInit(..., true)` for spoke context and chain `setCrosschainInProgress().setIsBalancesheetManager(...).save()`.
- **hubHandlers**: New handler `hub:UpdateBalanceSheetManager` — resolves account and pool manager on spoke and sets `crosschainInProgress` to `CanManage` or `CanNotManage` from hub event args.

## Files

- `ponder.schema.ts` — enum + column
- `src/services/PoolManagerService.ts` — crosschain state + logging
- `src/handlers/balanceSheetHandlers.ts` — refactor to crosschain flow
- `src/handlers/hubHandlers.ts` — new hub handler
