### PR TITLE
feat: track adapters per pool

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -102,6 +102,7 @@ export const PoolRelations = relations(Pool, ({ one, many }) => ({
   merkleProofManagers: many(MerkleProofManager, {
     relationName: "merkleProofManagers",
   }),
+  poolAdapters: many(PoolAdapter),
 }));
 
 const PoolSpokeBlockchainColumns = (t: PgColumnsBuilders) => ({
@@ -1305,6 +1306,7 @@ export const AdapterRelations = relations(Adapter, ({ many }) => ({
   adapterWirings: many(AdapterWiring, {
     relationName: "adapterWirings",
   }),
+  poolAdapters: many(PoolAdapter),
 }));
 
 const AdapterWiringColumns = (t: PgColumnsBuilders) => ({
@@ -1328,6 +1330,53 @@ export const AdapterWiringRelations = relations(AdapterWiring, ({ one }) => ({
   toAdapter: one(Adapter, {
     fields: [AdapterWiring.toAddress, AdapterWiring.toCentrifugeId],
     references: [Adapter.address, Adapter.centrifugeId],
+  }),
+}));
+
+export const PoolAdapterCrosschainInProgressTypes = [`Enabled`, `Disabled`] as const;
+export const PoolAdapterCrosschainInProgress = onchainEnum(
+  "pool_adapter_crosschain_in_progress",
+  PoolAdapterCrosschainInProgressTypes
+);
+
+const PoolAdapterColumns = (t: PgColumnsBuilders) => ({
+  localCentrifugeId: t.text().notNull(),
+  remoteCentrifugeId: t.text().notNull(),
+  poolId: t.bigint().notNull(),
+  adapterAddress: t.hex().notNull(),
+  isEnabled: t.boolean().notNull().default(false),
+  crosschainInProgress: PoolAdapterCrosschainInProgress("pool_adapter_crosschain_in_progress"),
+  ...defaultColumns(t),
+});
+
+export const PoolAdapter = onchainTable("pool_adapter", PoolAdapterColumns, (t) => ({
+  id: primaryKey({
+    columns: [t.localCentrifugeId, t.remoteCentrifugeId, t.poolId, t.adapterAddress],
+  }),
+  poolIdx: index().on(t.poolId),
+  adapterAddressIdx: index().on(t.adapterAddress),
+  localCentrifugeIdIdx: index().on(t.localCentrifugeId),
+  remoteCentrifugeIdIdx: index().on(t.remoteCentrifugeId),
+  isEnabledIdx: index().on(t.isEnabled),
+  crosschainInProgressIdx: index().on(t.crosschainInProgress),
+}));
+
+export const PoolAdapterRelations = relations(PoolAdapter, ({ one }) => ({
+  pool: one(Pool, {
+    fields: [PoolAdapter.poolId],
+    references: [Pool.id],
+  }),
+  adapter: one(Adapter, {
+    fields: [PoolAdapter.adapterAddress, PoolAdapter.localCentrifugeId],
+    references: [Adapter.address, Adapter.centrifugeId],
+  }),
+  localBlockchain: one(Blockchain, {
+    fields: [PoolAdapter.localCentrifugeId],
+    references: [Blockchain.centrifugeId],
+  }),
+  remoteBlockchain: one(Blockchain, {
+    fields: [PoolAdapter.remoteCentrifugeId],
+    references: [Blockchain.centrifugeId],
   }),
 }));
 

--- a/src/handlers/gatewayHandlers.ts
+++ b/src/handlers/gatewayHandlers.ts
@@ -1,7 +1,7 @@
 import { CrosschainMessage } from "ponder:schema";
 import { multiMapper } from "../helpers/multiMapper";
 import { logEvent, serviceError } from "../helpers/logger";
-import { BlockchainService } from "../services";
+import { BlockchainService, PoolAdapterService } from "../services";
 import type { DataWithoutDefaults } from "../services/Service";
 import { timestamper } from "../helpers/timestamper";
 
@@ -88,6 +88,22 @@ multiMapper("gateway:PrepareMessage", async ({ event, context }) => {
     },
     event
   )) as CrosschainMessageService | null;
+
+  // TODO: move this event info to a proper in Hub.SetAdapters event.
+  const setPoolAdapters = PoolAdapterService.parseSetPoolAdaptersMessageData(data);
+  if (setPoolAdapters) {
+    await PoolAdapterService.setCrosschainInProgressFromMessage(
+      context,
+      {
+        localCentrifugeId: toCentrifugeId.toString(),
+        remoteCentrifugeId: fromCentrifugeId,
+        poolId: setPoolAdapters.poolId,
+        adapterAddresses: setPoolAdapters.adapterAddresses,
+        enabledTransition: true,
+      },
+      event
+    );
+  }
 });
 
 multiMapper("gateway:UnderpaidBatch", async ({ event, context }) => {
@@ -354,12 +370,25 @@ multiMapper("gateway:FailMessage", async ({ event, context }) => {
     return;
   }
 
-  const { status, payloadId, payloadIndex: failPayloadIndex } = crosschainMessage.read();
+  const { status, payloadId, payloadIndex: failPayloadIndex, data } = crosschainMessage.read();
   if (status === "Failed") return;
 
   crosschainMessage.setStatus("Failed");
   crosschainMessage.setFailReason(error);
   await crosschainMessage.save(event);
+
+  const setPoolAdapters = PoolAdapterService.parseSetPoolAdaptersMessageData(data);
+  if (setPoolAdapters) {
+    await PoolAdapterService.clearCrosschainInProgress(
+      context,
+      {
+        localCentrifugeId: toCentrifugeId,
+        remoteCentrifugeId: fromCentrifugeId.toString(),
+        poolId: setPoolAdapters.poolId,
+      },
+      event
+    );
+  }
 
   if (!payloadId || failPayloadIndex == null)
     return serviceError("Payload ID and index are required");

--- a/src/handlers/multiAdapterHandlers.ts
+++ b/src/handlers/multiAdapterHandlers.ts
@@ -4,6 +4,7 @@ import {
   BlockchainService,
   AdapterService,
   AdapterParticipationService,
+  PoolAdapterService,
   AdapterWiringService,
   CrosschainMessageService,
   CrosschainPayloadService,
@@ -283,6 +284,25 @@ multiMapper("multiAdapter:HandleProof", async ({ event, context }) => {
 
   crosschainPayload.completed(event);
   await crosschainPayload.save(event);
+});
+
+multiMapper("multiAdapter:SetAdapters", async ({ event, context }) => {
+  logEvent(event, context, "multiAdapter:SetAdapters");
+  const localCentrifugeId = await BlockchainService.getCentrifugeId(context);
+  const { centrifugeId: remoteCentrifugeId, poolId, adapters } = event.args;
+
+  await PoolAdapterService.syncFromSetAdapters(
+    context,
+    {
+      localCentrifugeId,
+      remoteCentrifugeId: remoteCentrifugeId.toString(),
+      poolId,
+      adapterAddresses: adapters.map(
+        (adapter) => (adapter as string).toLowerCase() as `0x${string}`
+      ),
+    },
+    event
+  );
 });
 
 multiMapper(

--- a/src/services/PoolAdapterService.ts
+++ b/src/services/PoolAdapterService.ts
@@ -1,0 +1,231 @@
+import type { Context, Event } from "ponder:registry";
+import { PoolAdapter, PoolAdapterCrosschainInProgressTypes } from "ponder:schema";
+import { serviceError, serviceLog } from "../helpers/logger";
+import { formatBytes32ToAddress } from "../helpers/formatter";
+import { Service } from "./Service";
+
+type PoolAdapterKey = {
+  localCentrifugeId: string;
+  remoteCentrifugeId: string;
+  poolId: bigint;
+};
+
+type SetPoolAdaptersMessageData = {
+  poolId: bigint;
+  adapterAddresses: `0x${string}`[];
+};
+
+/**
+ * Service for pool-to-adapter mappings on a specific local/remote chain pair.
+ */
+export class PoolAdapterService extends Service<typeof PoolAdapter> {
+  static readonly entityTable = PoolAdapter;
+  static readonly entityName = "PoolAdapter";
+
+  /** Sets whether the adapter is active in the latest local mapping. */
+  public setEnabled(isEnabled: boolean) {
+    this.data.isEnabled = isEnabled;
+    serviceLog(`Setting isEnabled to ${isEnabled}`);
+    return this;
+  }
+
+  /** Sets or clears the pending remote enable/disable transition. */
+  public setCrosschainInProgress(
+    crosschainInProgress?: (typeof PoolAdapterCrosschainInProgressTypes)[number]
+  ) {
+    this.data.crosschainInProgress = crosschainInProgress ?? null;
+    serviceLog(`Setting crosschainInProgress to ${crosschainInProgress}`);
+    return this;
+  }
+
+  /** Applies the authoritative local `SetAdapters` event for a chain/pool/remote set. */
+  static async syncFromSetAdapters(
+    context: Context,
+    input: PoolAdapterKey & { adapterAddresses: `0x${string}`[] },
+    event: Event
+  ) {
+    const { localCentrifugeId, remoteCentrifugeId, poolId } = input;
+    const adapterAddresses = this.normalizeAddresses(input.adapterAddresses);
+    serviceLog(
+      `Syncing PoolAdapter mapping for ${localCentrifugeId}->${remoteCentrifugeId} pool ${poolId}`
+    );
+
+    const existing = await this.getSetRows(context, {
+      localCentrifugeId,
+      remoteCentrifugeId,
+      poolId,
+    });
+    const existingByAddress = new Map(
+      existing.map((poolAdapter) => [poolAdapter.read().adapterAddress.toLowerCase(), poolAdapter])
+    );
+    const nextAddresses = new Set(adapterAddresses);
+    const instances: PoolAdapterService[] = [];
+
+    for (const poolAdapter of existing) {
+      const { adapterAddress } = poolAdapter.read();
+      const normalizedAddress = adapterAddress.toLowerCase() as `0x${string}`;
+      poolAdapter.setEnabled(nextAddresses.has(normalizedAddress)).setCrosschainInProgress();
+      instances.push(poolAdapter);
+    }
+
+    for (const adapterAddress of adapterAddresses) {
+      if (existingByAddress.has(adapterAddress)) continue;
+      const poolAdapter = (await this.insert(
+        context,
+        {
+          localCentrifugeId,
+          remoteCentrifugeId,
+          poolId,
+          adapterAddress,
+          isEnabled: true,
+          crosschainInProgress: null,
+        },
+        event,
+        true
+      )) as PoolAdapterService | null;
+      if (!poolAdapter) continue;
+      instances.push(poolAdapter);
+    }
+
+    if (instances.length > 0) await this.saveMany(context, instances, event);
+  }
+
+  /** Marks destination-side rows as pending based on an outbound `SetPoolAdapters` message. */
+  static async setCrosschainInProgressFromMessage(
+    context: Context,
+    input: PoolAdapterKey & {
+      adapterAddresses: `0x${string}`[];
+      enabledTransition: boolean;
+    },
+    event: Event
+  ) {
+    const { localCentrifugeId, remoteCentrifugeId, poolId, enabledTransition } = input;
+    const adapterAddresses = this.normalizeAddresses(input.adapterAddresses);
+    serviceLog(
+      `Marking PoolAdapter crosschainInProgress for ${localCentrifugeId}->${remoteCentrifugeId} pool ${poolId}`
+    );
+
+    const existing = await this.getSetRows(context, {
+      localCentrifugeId,
+      remoteCentrifugeId,
+      poolId,
+    });
+    const existingByAddress = new Map(
+      existing.map((poolAdapter) => [poolAdapter.read().adapterAddress.toLowerCase(), poolAdapter])
+    );
+    const nextAddresses = new Set(adapterAddresses);
+    const transition: (typeof PoolAdapterCrosschainInProgressTypes)[number] = enabledTransition
+      ? "Enabled"
+      : "Disabled";
+    const inverseTransition: (typeof PoolAdapterCrosschainInProgressTypes)[number] =
+      enabledTransition ? "Disabled" : "Enabled";
+    const instances: PoolAdapterService[] = [];
+
+    for (const poolAdapter of existing) {
+      const { adapterAddress } = poolAdapter.read();
+      const normalizedAddress = adapterAddress.toLowerCase() as `0x${string}`;
+      poolAdapter.setCrosschainInProgress(
+        nextAddresses.has(normalizedAddress) ? transition : inverseTransition
+      );
+      instances.push(poolAdapter);
+    }
+
+    for (const adapterAddress of adapterAddresses) {
+      if (existingByAddress.has(adapterAddress)) continue;
+      const poolAdapter = (await this.insert(
+        context,
+        {
+          localCentrifugeId,
+          remoteCentrifugeId,
+          poolId,
+          adapterAddress,
+          isEnabled: false,
+          crosschainInProgress: transition,
+        },
+        event,
+        true
+      )) as PoolAdapterService | null;
+      if (!poolAdapter) continue;
+      instances.push(poolAdapter);
+    }
+
+    if (instances.length > 0) await this.saveMany(context, instances, event);
+  }
+
+  /** Clears pending remote state for a chain/pool/remote set. */
+  static async clearCrosschainInProgress(context: Context, input: PoolAdapterKey, event: Event) {
+    const existing = await this.getSetRows(context, input);
+    const instances = existing.filter(
+      (poolAdapter) => poolAdapter.read().crosschainInProgress != null
+    );
+    for (const poolAdapter of instances) poolAdapter.setCrosschainInProgress();
+    if (instances.length > 0) await this.saveMany(context, instances, event);
+  }
+
+  /** Parses decoded `SetPoolAdapters` message data into a pool id and remote adapter addresses. */
+  static parseSetPoolAdaptersMessageData(data: unknown): SetPoolAdaptersMessageData | null {
+    if (!data || typeof data !== "object") return null;
+
+    const poolIdValue = "poolId" in data ? data.poolId : undefined;
+    const adapterListValue = "adapterList" in data ? data.adapterList : undefined;
+    if (
+      (typeof poolIdValue !== "string" &&
+        typeof poolIdValue !== "number" &&
+        typeof poolIdValue !== "bigint") ||
+      typeof adapterListValue !== "string"
+    ) {
+      return null;
+    }
+
+    try {
+      return {
+        poolId: BigInt(poolIdValue),
+        adapterAddresses: this.decodeAdapterList(adapterListValue as `0x${string}`),
+      };
+    } catch (error) {
+      serviceError(
+        `Failed to parse SetPoolAdapters message data: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return null;
+    }
+  }
+
+  /** Loads all pool-adapter rows for one local/remote/pool set. */
+  private static async getSetRows(context: Context, input: PoolAdapterKey) {
+    return (await this.query(context, {
+      localCentrifugeId: input.localCentrifugeId,
+      remoteCentrifugeId: input.remoteCentrifugeId,
+      poolId: input.poolId,
+    })) as PoolAdapterService[];
+  }
+
+  /** Lowercases and deduplicates adapter addresses. */
+  private static normalizeAddresses(adapterAddresses: `0x${string}`[]) {
+    return Array.from(
+      new Set(
+        adapterAddresses.map((adapterAddress) => adapterAddress.toLowerCase() as `0x${string}`)
+      )
+    );
+  }
+
+  /** Decodes the bytes payload used by `SetPoolAdapters` into adapter addresses. */
+  private static decodeAdapterList(adapterList: `0x${string}`) {
+    const hex = adapterList.slice(2).toLowerCase();
+    if (hex.length < 4) return [] as `0x${string}`[];
+
+    const adapterCount = Number.parseInt(hex.slice(0, 4), 16);
+    const addresses: `0x${string}`[] = [];
+    let offset = 4;
+    for (let i = 0; i < adapterCount; i++) {
+      const word = hex.slice(offset, offset + 64);
+      if (word.length !== 64) {
+        throw new Error(`Invalid adapterList length for adapter index ${i}`);
+      }
+      addresses.push(formatBytes32ToAddress(`0x${word}`));
+      offset += 64;
+    }
+    return this.normalizeAddresses(addresses);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -28,6 +28,7 @@ export * from "./OutstandingRedeemService"; // TODO: DEPRECATED to be deleted in
 export * from "./PendingInvestOrderService";
 export * from "./PendingRedeemOrderService";
 export * from "./PolicyService";
+export * from "./PoolAdapterService";
 export * from "./PoolManagerService";
 export * from "./PoolService";
 export * from "./PoolSpokeBlockchainService";


### PR DESCRIPTION
in hub.sol SetAdapters does not emit, so the event is catched on gateway;PrepareMessage.

I've left a TODO to handle it more cleanly.