### PR TITLE
feat: add per user realized performance tracking

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -1464,6 +1464,7 @@ export const PoolSnapshotRelations = relations(PoolSnapshot, ({ one }) => ({
   }),
 }));
 
+/** Dynamic TokenSnapshot yield bigint columns derived from configured yield specs. */
 function tokenYieldSnapshotColumns(t: PgColumnsBuilders) {
   const cols: Record<string, ReturnType<PgColumnsBuilders["bigint"]>> = {};
   for (const spec of TOKEN_YIELD_SPECS) {
@@ -1598,6 +1599,10 @@ const TokenInstancePositionColumns = (t: PgColumnsBuilders) => ({
   centrifugeId: t.text().notNull(),
   accountAddress: t.hex().notNull(),
   balance: t.bigint().default(0n),
+  tokenPriceAtLastChange: t.bigint(),
+  cumulativeEarnings: t.bigint().notNull().default(0n),
+  costBasis: t.bigint().notNull().default(0n),
+  cumulativeRealizedPnl: t.bigint().notNull().default(0n),
   isFrozen: t.boolean().notNull().default(false), //TODO: Deprecate this column
   ...defaultColumns(t),
 });
@@ -1623,6 +1628,55 @@ export const TokenInstancePositionRelations = relations(TokenInstancePosition, (
     references: [Account.address],
   }),
 }));
+
+/** Immutable per-transfer investor accounting checkpoints on a token instance. */
+const InvestorPositionCheckpointColumns = (t: PgColumnsBuilders) => ({
+  tokenId: t.hex().notNull(),
+  centrifugeId: t.text().notNull(),
+  accountAddress: t.hex().notNull(),
+  poolId: t.bigint().notNull(),
+  balanceBefore: t.bigint().notNull(),
+  balanceAfter: t.bigint().notNull(),
+  tokenPrice: t.bigint(),
+  periodEarnings: t.bigint(),
+  cumulativeEarnings: t.bigint().notNull().default(0n),
+  costBasisBefore: t.bigint().notNull().default(0n),
+  costBasisAfter: t.bigint().notNull().default(0n),
+  realizedPnl: t.bigint(),
+  cumulativeRealizedPnl: t.bigint().notNull().default(0n),
+  trigger: t.text().notNull(),
+  logIndex: t.integer().notNull(),
+  ...defaultColumns(t, false),
+});
+
+export const InvestorPositionCheckpoint = onchainTable(
+  "investor_position_checkpoint",
+  InvestorPositionCheckpointColumns,
+  (t) => ({
+    id: primaryKey({
+      columns: [t.tokenId, t.centrifugeId, t.accountAddress, t.createdAtBlock, t.logIndex],
+    }),
+    accountTokenCreatedAtIdx: index().on(t.accountAddress, t.tokenId, t.centrifugeId, t.createdAt),
+  })
+);
+
+export const InvestorPositionCheckpointRelations = relations(
+  InvestorPositionCheckpoint,
+  ({ one }) => ({
+    tokenInstance: one(TokenInstance, {
+      fields: [InvestorPositionCheckpoint.tokenId, InvestorPositionCheckpoint.centrifugeId],
+      references: [TokenInstance.tokenId, TokenInstance.centrifugeId],
+    }),
+    account: one(Account, {
+      fields: [InvestorPositionCheckpoint.accountAddress],
+      references: [Account.address],
+    }),
+    pool: one(Pool, {
+      fields: [InvestorPositionCheckpoint.poolId],
+      references: [Pool.id],
+    }),
+  })
+);
 
 const MerkleProofManagerColumns = (t: PgColumnsBuilders) => ({
   address: t.hex().notNull(),

--- a/src/handlers/tokenInstanceHandlers.ts
+++ b/src/handlers/tokenInstanceHandlers.ts
@@ -1,11 +1,13 @@
 import { multiMapper } from "../helpers/multiMapper";
-import { logEvent, serviceError, serviceLog } from "../helpers/logger";
+import { logEvent, serviceError, serviceLog, serviceWarn } from "../helpers/logger";
+import { computeInvestorPositionCheckpoint } from "../helpers/investorPositionCheckpoint";
 import {
   BlockchainService,
   DeploymentService,
   TokenInstanceService,
   TokenInstancePositionService,
   AccountService,
+  InvestorPositionCheckpointService,
   TokenService,
   InvestorTransactionService,
   EscrowService,
@@ -34,6 +36,7 @@ multiMapper("tokenInstance:Transfer", async ({ event, context }) => {
   const token = (await TokenService.get(context, { id: tokenId })) as TokenService | null;
   if (!token) return serviceError(`Token not found. Cannot retrieve poolId`);
   const { poolId } = token.read();
+  const { tokenPrice } = tokenInstance.read();
 
   const [isFromNull, isToNull] = [BigInt(from) === 0n, BigInt(to) === 0n];
 
@@ -67,48 +70,155 @@ multiMapper("tokenInstance:Transfer", async ({ event, context }) => {
     !isToNull && !isToGlobalEscrow && !isToPoolEscrow,
   ];
 
-  if (isFromUserAccount) {
-    const _fromAccount = await AccountService.getOrInit(context, { address: from }, event);
-    const fromPosition = (await TokenInstancePositionService.getOrInit(
-      context,
-      {
-        tokenId: tokenId,
-        centrifugeId,
-        accountAddress: from,
-      },
-      event,
-      async (tokenInstancePosition) =>
-        await initialisePosition(context, event, tokenAddress, tokenInstancePosition)
-    )) as TokenInstancePositionService;
-    const { createdAtBlock } = fromPosition.read();
-    if (!createdAtBlock) {
-      serviceError(`TokenInstancePosition not found. Cannot update balance`);
-      return;
-    }
-    if (createdAtBlock < Number(event.block.number)) fromPosition.subBalance(amount);
-    await fromPosition.save(event);
-  }
+  const isSelfTransfer = isFromUserAccount && isToUserAccount && from === to;
+  const trigger = "tokenInstance:Transfer" as const;
+  const logIndex = event.log.logIndex;
 
-  if (isToUserAccount) {
-    const _toAccount = await AccountService.getOrInit(context, { address: to }, event);
-    const toPosition = (await TokenInstancePositionService.getOrInit(
+  const handleUserPositionChange = async ({
+    accountAddress,
+    isIncrease,
+  }: {
+    accountAddress: `0x${string}`;
+    isIncrease: boolean;
+  }) => {
+    await AccountService.getOrInit(context, { address: accountAddress }, event);
+
+    const positionQuery = {
+      tokenId,
+      centrifugeId,
+      accountAddress,
+    } as const;
+
+    const existingPosition = (await TokenInstancePositionService.get(
       context,
-      {
-        tokenId: tokenId,
-        centrifugeId,
-        accountAddress: to,
-      },
-      event,
-      async (tokenInstancePosition) =>
-        await initialisePosition(context, event, tokenAddress, tokenInstancePosition)
-    )) as TokenInstancePositionService;
-    const { createdAtBlock } = toPosition.read();
-    if (!createdAtBlock) {
-      serviceError(`TokenInstancePosition not found. Cannot update balance`);
+      positionQuery
+    )) as TokenInstancePositionService | null;
+    const position = (existingPosition ??
+      ((await TokenInstancePositionService.getOrInit(
+        context,
+        positionQuery,
+        event,
+        async (tokenInstancePosition) =>
+          await initialisePosition(context, event, tokenAddress, tokenInstancePosition)
+      )) as TokenInstancePositionService)) as TokenInstancePositionService;
+
+    const positionData = position.read();
+    const positionAlreadyExisted = existingPosition !== null;
+    const currentBalance = positionData.balance ?? 0n;
+
+    if (!positionAlreadyExisted && !isIncrease) {
+      serviceWarn(
+        "InvestorPositionCheckpoint invariant violated: first-seen sender position on Transfer",
+        `tokenId=${tokenId}`,
+        `centrifugeId=${centrifugeId}`,
+        `accountAddress=${accountAddress}`,
+        `txHash=${event.transaction.hash}`,
+        `block=${event.block.number}`,
+        `amount=${amount}`
+      );
       return;
     }
-    if (createdAtBlock < Number(event.block.number)) toPosition.addBalance(amount);
-    await toPosition.save(event);
+
+    const balanceBefore = positionAlreadyExisted ? currentBalance : 0n;
+    const balanceAfter = positionAlreadyExisted
+      ? isIncrease
+        ? currentBalance + amount
+        : currentBalance - amount
+      : amount;
+
+    if (!positionAlreadyExisted && isIncrease && currentBalance !== amount) {
+      serviceWarn(
+        "InvestorPositionCheckpoint invariant violated: first-seen recipient balance mismatch",
+        `tokenId=${tokenId}`,
+        `centrifugeId=${centrifugeId}`,
+        `accountAddress=${accountAddress}`,
+        `txHash=${event.transaction.hash}`,
+        `block=${event.block.number}`,
+        `amount=${amount}`,
+        `initializedBalance=${currentBalance}`
+      );
+      return;
+    }
+
+    if (tokenPrice === null || tokenPrice <= 0n) {
+      serviceWarn(
+        "InvestorPositionCheckpoint skipped due to unknown token price",
+        `tokenId=${tokenId}`,
+        `centrifugeId=${centrifugeId}`,
+        `accountAddress=${accountAddress}`,
+        `txHash=${event.transaction.hash}`,
+        `block=${event.block.number}`,
+        `amount=${amount}`
+      );
+      if (positionAlreadyExisted) {
+        await position.setBalance(balanceAfter).save(event);
+      }
+      return;
+    }
+
+    const accounting = computeInvestorPositionCheckpoint({
+      amount,
+      balanceBefore,
+      balanceAfter,
+      tokenPrice,
+      tokenPriceAtLastChange: positionData.tokenPriceAtLastChange ?? null,
+      cumulativeEarningsBefore: positionData.cumulativeEarnings ?? 0n,
+      costBasisBefore: positionData.costBasis ?? 0n,
+      cumulativeRealizedPnlBefore: positionData.cumulativeRealizedPnl ?? 0n,
+      isIncrease,
+    });
+
+    await InvestorPositionCheckpointService.createCheckpoint(
+      context,
+      {
+        tokenId,
+        centrifugeId,
+        accountAddress,
+        poolId,
+        balanceBefore,
+        balanceAfter,
+        tokenPrice,
+        periodEarnings: accounting.periodEarnings,
+        cumulativeEarnings: accounting.cumulativeEarningsAfter,
+        costBasisBefore: positionData.costBasis ?? 0n,
+        costBasisAfter: accounting.costBasisAfter,
+        realizedPnl: accounting.realizedPnl,
+        cumulativeRealizedPnl: accounting.cumulativeRealizedPnlAfter,
+        trigger,
+        logIndex,
+      },
+      event
+    );
+
+    await position
+      .applyCheckpointAccounting({
+        balanceAfter,
+        tokenPrice,
+        cumulativeEarnings: accounting.cumulativeEarningsAfter,
+        costBasisAfter: accounting.costBasisAfter,
+        cumulativeRealizedPnl: accounting.cumulativeRealizedPnlAfter,
+      })
+      .save(event);
+  };
+
+  if (isSelfTransfer) {
+    serviceWarn(
+      "InvestorPositionCheckpoint skipped for self-transfer",
+      `tokenId=${tokenId}`,
+      `centrifugeId=${centrifugeId}`,
+      `accountAddress=${from}`,
+      `txHash=${event.transaction.hash}`,
+      `block=${event.block.number}`,
+      `amount=${amount}`
+    );
+  } else {
+    if (isFromUserAccount) {
+      await handleUserPositionChange({ accountAddress: from, isIncrease: false });
+    }
+
+    if (isToUserAccount) {
+      await handleUserPositionChange({ accountAddress: to, isIncrease: true });
+    }
   }
 
   // Handle tokenInstance and token total issuance change

--- a/src/handlers/tokenInstanceHandlers.ts
+++ b/src/handlers/tokenInstanceHandlers.ts
@@ -89,21 +89,19 @@ multiMapper("tokenInstance:Transfer", async ({ event, context }) => {
       accountAddress,
     } as const;
 
-    const existingPosition = (await TokenInstancePositionService.get(
+    let positionWasInitialized = false;
+    const position = (await TokenInstancePositionService.getOrInit(
       context,
-      positionQuery
-    )) as TokenInstancePositionService | null;
-    const position = (existingPosition ??
-      ((await TokenInstancePositionService.getOrInit(
-        context,
-        positionQuery,
-        event,
-        async (tokenInstancePosition) =>
-          await initialisePosition(context, event, tokenAddress, tokenInstancePosition)
-      )) as TokenInstancePositionService)) as TokenInstancePositionService;
+      positionQuery,
+      event,
+      async (tokenInstancePosition) => {
+        positionWasInitialized = true;
+        await initialisePosition(context, event, tokenAddress, tokenInstancePosition);
+      }
+    )) as TokenInstancePositionService;
 
     const positionData = position.read();
-    const positionAlreadyExisted = existingPosition !== null;
+    const positionAlreadyExisted = !positionWasInitialized;
     const currentBalance = positionData.balance ?? 0n;
 
     if (!positionAlreadyExisted && !isIncrease) {

--- a/src/helpers/investorPositionCheckpoint.ts
+++ b/src/helpers/investorPositionCheckpoint.ts
@@ -63,8 +63,7 @@ export function computeInvestorPositionCheckpoint(
   } = input;
 
   const periodEarnings = computePeriodEarnings(balanceBefore, tokenPrice, tokenPriceAtLastChange);
-  const cumulativeEarningsAfter =
-    cumulativeEarningsBefore + (periodEarnings === null ? 0n : periodEarnings);
+  const cumulativeEarningsAfter = cumulativeEarningsBefore + (periodEarnings ?? 0n);
 
   if (isIncrease) {
     const costBasisAfter = costBasisBefore + amount * tokenPrice;

--- a/src/helpers/investorPositionCheckpoint.ts
+++ b/src/helpers/investorPositionCheckpoint.ts
@@ -1,0 +1,91 @@
+import { bigintMax } from "./bigintMath";
+
+export type InvestorPositionCheckpointComputationInput = {
+  amount: bigint;
+  balanceBefore: bigint;
+  balanceAfter: bigint;
+  tokenPrice: bigint;
+  tokenPriceAtLastChange: bigint | null;
+  cumulativeEarningsBefore: bigint;
+  costBasisBefore: bigint;
+  cumulativeRealizedPnlBefore: bigint;
+  isIncrease: boolean;
+};
+
+export type InvestorPositionCheckpointComputation = {
+  periodEarnings: bigint | null;
+  cumulativeEarningsAfter: bigint;
+  costBasisAfter: bigint;
+  realizedPnl: bigint;
+  cumulativeRealizedPnlAfter: bigint;
+};
+
+/**
+ * Price appreciation on the held balance between position changes.
+ */
+export function computePeriodEarnings(
+  balanceBefore: bigint,
+  currentTokenPrice: bigint,
+  previousTokenPrice: bigint | null
+) {
+  if (balanceBefore === 0n || previousTokenPrice === null || previousTokenPrice <= 0n) return null;
+  return balanceBefore * (currentTokenPrice - previousTokenPrice);
+}
+
+/**
+ * Realized cost basis removed on a decrease, using direct multiplication/division to avoid
+ * an intermediate average-cost bigint rounding step.
+ */
+export function computeRemovedCostBasis(
+  amount: bigint,
+  costBasisBefore: bigint,
+  balanceBefore: bigint
+) {
+  if (amount === 0n || costBasisBefore === 0n || balanceBefore === 0n) return 0n;
+  return (amount * costBasisBefore) / balanceBefore;
+}
+
+/**
+ * Computes checkpoint accounting fields for a balance change with a known positive token price.
+ */
+export function computeInvestorPositionCheckpoint(
+  input: InvestorPositionCheckpointComputationInput
+): InvestorPositionCheckpointComputation {
+  const {
+    amount,
+    balanceBefore,
+    tokenPrice,
+    tokenPriceAtLastChange,
+    cumulativeEarningsBefore,
+    costBasisBefore,
+    cumulativeRealizedPnlBefore,
+    isIncrease,
+  } = input;
+
+  const periodEarnings = computePeriodEarnings(balanceBefore, tokenPrice, tokenPriceAtLastChange);
+  const cumulativeEarningsAfter =
+    cumulativeEarningsBefore + (periodEarnings === null ? 0n : periodEarnings);
+
+  if (isIncrease) {
+    const costBasisAfter = costBasisBefore + amount * tokenPrice;
+    return {
+      periodEarnings,
+      cumulativeEarningsAfter,
+      costBasisAfter,
+      realizedPnl: 0n,
+      cumulativeRealizedPnlAfter: cumulativeRealizedPnlBefore,
+    };
+  }
+
+  const removedCostBasis = computeRemovedCostBasis(amount, costBasisBefore, balanceBefore);
+  const realizedPnl = amount * tokenPrice - removedCostBasis;
+  const costBasisAfter = bigintMax(costBasisBefore - removedCostBasis, 0n);
+
+  return {
+    periodEarnings,
+    cumulativeEarningsAfter,
+    costBasisAfter,
+    realizedPnl,
+    cumulativeRealizedPnlAfter: cumulativeRealizedPnlBefore + realizedPnl,
+  };
+}

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -90,3 +90,12 @@ export function serviceLog(...args: any[]) {
 export function serviceError(...args: any[]) {
   process.stderr.write("> [ERROR] " + args.join(" ") + "\n");
 }
+
+/**
+ * Logs a warning message to the console with a prefix.
+ *
+ * @param args - The arguments to log
+ */
+export function serviceWarn(...args: any[]) {
+  process.stderr.write("> [WARN] " + args.join(" ") + "\n");
+}

--- a/src/services/InvestorPositionCheckpointService.ts
+++ b/src/services/InvestorPositionCheckpointService.ts
@@ -1,0 +1,29 @@
+import type { Context, Event } from "ponder:registry";
+import { InvestorPositionCheckpoint } from "ponder:schema";
+import { expandInlineObject, serviceLog } from "../helpers/logger";
+import { Service } from "./Service";
+
+/**
+ * Service class for immutable investor position checkpoint rows.
+ */
+export class InvestorPositionCheckpointService extends Service<typeof InvestorPositionCheckpoint> {
+  static readonly entityTable = InvestorPositionCheckpoint;
+  static readonly entityName = "InvestorPositionCheckpoint";
+
+  /**
+   * Inserts a single investor position checkpoint for a transfer-side balance change.
+   */
+  static async createCheckpoint(
+    context: Context,
+    data: InvestorPositionCheckpointData,
+    event: Event
+  ) {
+    serviceLog("Creating investor position checkpoint", expandInlineObject(data));
+    return this.insert(context, data, event);
+  }
+}
+
+type InvestorPositionCheckpointData = Omit<
+  typeof InvestorPositionCheckpoint.$inferInsert,
+  "createdAt" | "createdAtBlock" | "createdAtTxHash"
+>;

--- a/src/services/TokenInstancePositionService.ts
+++ b/src/services/TokenInstancePositionService.ts
@@ -35,6 +35,17 @@ export class TokenInstancePositionService extends Service<typeof TokenInstancePo
   }
 
   /**
+   * Sets the balance for the token position.
+   *
+   * @param amount - The balance amount to set
+   * @returns The current service instance for method chaining
+   */
+  public setBalance(amount: bigint) {
+    this.data.balance = amount;
+    return this;
+  }
+
+  /**
    * Subtracts a balance from the token position.
    *
    * @param {bigint} balance - The amount to subtract from the balance
@@ -42,6 +53,71 @@ export class TokenInstancePositionService extends Service<typeof TokenInstancePo
    */
   public subBalance(amount: bigint) {
     this.data.balance = (this.data.balance ?? 0n) - amount;
+    return this;
+  }
+
+  /**
+   * Sets the token price observed on the latest balance change.
+   *
+   * @param price - The token price in WAD precision
+   * @returns The current service instance for method chaining
+   */
+  public setTokenPriceAtLastChange(price: bigint | null) {
+    this.data.tokenPriceAtLastChange = price;
+    return this;
+  }
+
+  /**
+   * Sets cumulative period earnings for the position.
+   *
+   * @param amount - The cumulative earnings amount
+   * @returns The current service instance for method chaining
+   */
+  public setCumulativeEarnings(amount: bigint) {
+    this.data.cumulativeEarnings = amount;
+    return this;
+  }
+
+  /**
+   * Sets the live cost basis for the position.
+   *
+   * @param amount - The new cost basis
+   * @returns The current service instance for method chaining
+   */
+  public setCostBasis(amount: bigint) {
+    this.data.costBasis = amount;
+    return this;
+  }
+
+  /**
+   * Sets cumulative realized pnl for the position.
+   *
+   * @param amount - The cumulative realized pnl amount
+   * @returns The current service instance for method chaining
+   */
+  public setCumulativeRealizedPnl(amount: bigint) {
+    this.data.cumulativeRealizedPnl = amount;
+    return this;
+  }
+
+  /**
+   * Applies checkpoint-derived accounting state to the latest position view.
+   *
+   * @param checkpoint - Derived accounting values for the position
+   * @returns The current service instance for method chaining
+   */
+  public applyCheckpointAccounting(checkpoint: {
+    balanceAfter: bigint;
+    tokenPrice: bigint;
+    cumulativeEarnings: bigint;
+    costBasisAfter: bigint;
+    cumulativeRealizedPnl: bigint;
+  }) {
+    this.data.balance = checkpoint.balanceAfter;
+    this.data.tokenPriceAtLastChange = checkpoint.tokenPrice;
+    this.data.cumulativeEarnings = checkpoint.cumulativeEarnings;
+    this.data.costBasis = checkpoint.costBasisAfter;
+    this.data.cumulativeRealizedPnl = checkpoint.cumulativeRealizedPnl;
     return this;
   }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -18,6 +18,7 @@ export * from "./HoldingEscrowService";
 export * from "./HoldingService";
 export * from "./InvestOrderService";
 export * from "./InvestorTransactionService";
+export * from "./InvestorPositionCheckpointService";
 export * from "./MerkleProofManagerService";
 export * from "./OffRampAddressService";
 export * from "./OffRampRelayerService";


### PR DESCRIPTION
Closes #310 

### TL;DR

Indexes **per-account realized P&amp;L and related accounting** on `tokenInstance:Transfer` by extending `token_instance_position`, appending immutable **`investor_position_checkpoint`** rows, and centralizing the math in a dedicated helper.

### Motivation (Why)

- **Problem:** The indexer tracked token instance positions (balances) but did not expose **investor-level performance**: cost basis, unrealized-style **period earnings** (price change on the prior balance), and **realized P&amp;L** when positions decrease.
- **Impact without this:** Consumers cannot answer “how did this wallet perform on this share token?” from the API/indexer alone; product and analytics depend on off-chain recomputation or approximations.

### What changed

**Schema (`ponder.schema.ts`)**

- **`TokenInstancePosition`:** Adds `tokenPriceAtLastChange`, `cumulativeEarnings`, `costBasis`, `cumulativeRealizedPnl` (with sensible defaults where applicable).
- **`InvestorPositionCheckpoint`:** New **`investor_position_checkpoint`** table: one row per handled transfer side, keyed by `(tokenId, centrifugeId, accountAddress, createdAtBlock, logIndex)` with pool, balances before/after, price, earnings and P&amp;L fields, trigger and `logIndex`. Relations to `TokenInstance`, `Account`, `Pool`.
- Minor: JSDoc on dynamic token yield snapshot columns.

**Handlers (`tokenInstanceHandlers.ts`)**

- On **`tokenInstance:Transfer`**, reads **`tokenPrice`** from the token instance and refactors sender/receiver updates into **`handleUserPositionChange`** (increase vs decrease).
- **Self-transfers** (`from === to` and both user paths): checkpoint **skipped** (warning logged).
- When **`tokenPrice` is null or non-positive:** checkpoint **skipped**; existing positions still get **balance** updated via `setBalance` so balances stay consistent (no accounting row).
- **Invariant warnings** (new `serviceWarn`): e.g. first-seen sender on decrease, first-seen recipient balance mismatch—handler **returns early** without writing a checkpoint in those cases.
- Otherwise: **`computeInvestorPositionCheckpoint`**, **`InvestorPositionCheckpointService.createCheckpoint`**, then **`applyCheckpointAccounting`** on the position.

**Pure logic (`investorPositionCheckpoint.ts`)**

- **`computePeriodEarnings`:** `balanceBefore * (currentPrice - previousPrice)` when prior price exists and balance &gt; 0.
- **`computeRemovedCostBasis`:** pro-rata removal on decreases: `(amount * costBasisBefore) / balanceBefore`.
- **`computeInvestorPositionCheckpoint`:** combines the above; increases extend cost basis and keep realized P&amp;L; decreases compute **realized P&amp;L** and update cumulative realized P&amp;L and cost basis (with **`bigintMax`** guard).

**Services**

- **`InvestorPositionCheckpointService`:** thin `createCheckpoint` → `insert` with logging.
- **`TokenInstancePositionService`:** `setBalance`, setters for new fields, **`applyCheckpointAccounting`** chaining for checkpoint output.

**Logging (`logger.ts`)**

- **`serviceWarn`:** stderr `[WARN]` prefix for non-fatal issues (skipped checkpoints, invariants).

**Exports (`services/index.ts`)**

- Re-exports **`InvestorPositionCheckpointService`**.

### How to test / verification

- **Automated:** No new or changed tests in this diff.
- **Local / CI (expected for this repo):** After merging or when validating the branch, from repo root run **`pnpm update-registry`** (mainnet per project rules), **`pnpm codegen`** because **`ponder.schema.ts`** changed, then **`pnpm typecheck`** and **`pnpm lint`**.
- **Indexer:** Run Ponder against a chain that emits `tokenInstance:Transfer`; confirm **`investor_position_checkpoint`** rows for non–self-transfer user legs when `tokenPrice` is set; confirm balances still update when price is missing; inspect logs for `serviceWarn` paths (self-transfer, bad price, invariants).
- **Visuals:** N/A (backend/indexer only).

### Risk &amp; rollout

- **Schema migration / backfill:** New columns default to **0** / null as defined; **existing positions** gain full accounting only as **new transfers** are processed unless you **reindex** from scratch (or run a dedicated backfill—**not in this diff**).
- **Correctness assumptions:** Accounting uses **token instance `tokenPrice`** at transfer time and **position** `tokenPriceAtLastChange`; if price is stale or decimals differ from expectations, P&amp;L semantics may diverge from an off-chain model.
- **Early returns on warnings:** Some edge cases skip checkpoint writes; **balances** may still be advanced in the “unknown price” path—reviewers should confirm that matches product intent for partial data.
- **Rollback:** Revert the PR and redeploy the previous indexer image; DB may already contain new table/column data—plan whether to drop or keep for partial deployments.

### Registry / codegen note

- This branch **does not modify `generated/`** or lockfiles in the recorded diff; **Ponder schema did change**, so **`pnpm codegen`** is required after pull/merge before a clean build. If CI does not run codegen implicitly, ensure it does for this PR.


**Atomic PR note:** The change is a single cohesive feature (schema + handler + math + services). No split recommended unless you want schema/migration in one PR and handler wiring in a follow-up (usually unnecessary here).