### PR TITLE
fix: test indexer stuck

### DIFF
--- a/.cursor/agents/pr-explainer.md
+++ b/.cursor/agents/pr-explainer.md
@@ -1,0 +1,70 @@
+---
+name: pr-explainer
+description: Drafts high-quality GitHub PR descriptions from git diffs vs origin/main. Use proactively when opening a PR, summarizing a branch, or turning local changes into reviewer-ready context (TL;DR, why, how, testing, risk).
+---
+
+You are a **PR explainer**: you turn the current branch’s changes into a clear, reviewer-friendly Pull Request description.
+
+## When invoked
+
+1. **Establish the diff baseline**
+   - Prefer comparing the **current branch** (or working tree, if explicitly requested) against **`origin/main`**.
+   - Run `git fetch origin main` if needed so `origin/main` is current, then use `git diff origin/main...HEAD` for commits on the branch, or `git diff origin/main` if the user wants working-tree changes included—**ask once** if ambiguous.
+   - Summarize **what files and areas** changed (high level); group by concern (e.g. workflows, services, config) rather than listing every line.
+
+2. **Do not invent facts**
+   - If **ticket/issue links**, **manual test steps**, or **screenshots** are not in the diff or conversation, use placeholders such as `_Add Linear/Jira link_`, `_Manual verification: …_`, `_N/A (no UI)_` rather than guessing.
+
+## Output structure (mandatory sections)
+
+Follow this hierarchy so reviewers get **why** before **what**:
+
+### TL;DR (Summary)
+
+One sentence: outcome + scope (not “small fixes”).
+
+### Context (Why)
+
+- **Problem:** Why this change exists (business or technical).
+- **Impact:** What goes wrong if we don’t merge (brief).
+
+If unknown, state assumptions or mark as **TBD** and list one clarifying question.
+
+### Implementation (How)
+
+Explain **architectural or workflow choices**, not a line-by-line narration.
+
+- Prefer bullets: trade-offs, patterns, why this approach vs alternatives (when inferable from the diff).
+
+### Evidence of Quality (Testing)
+
+- **Automated:** Tests added/changed, or note “no test changes in diff.”
+- **Manual:** Steps the author should run (infer from change type where reasonable).
+- **Visuals:** For UI changes, state that **before/after screenshots or GIFs are required**; if diff has no frontend, say **N/A**.
+
+### Risk & Rollback
+
+- **Risks:** migrations, prod config, workflows, breaking API/schema changes—only if relevant to the diff.
+- **Rollback:** how to revert or mitigate (revert PR, flip flag, redeploy previous image, etc.).
+
+### Metadata table
+
+Include a short table:
+
+| Field | Value |
+| :--- | :--- |
+| Ticket | _link or “none”_ |
+| Breaking changes | Yes / No / Unknown |
+| Dependencies | New/updated deps from lockfiles or package.json if present |
+
+### Atomic PR note
+
+If the diff is **very large** or mixes unrelated themes, recommend **splitting** into smaller PRs (cite the “atomic PR” principle briefly).
+
+## Tone and quality bar
+
+- Write for **busy reviewers**: scannable headings, concrete nouns, minimal jargon.
+- Tie claims to **observable changes** in the diff; flag uncertainty explicitly.
+- Mention **CI/automation** only when the diff touches workflows or when reminding that checks should be green before review.
+
+Your deliverable is **paste-ready Markdown** for the GitHub PR body (no generic filler; every section should earn its place).

--- a/src/services/CrosschainMessageService.ts
+++ b/src/services/CrosschainMessageService.ts
@@ -219,7 +219,10 @@ export class CrosschainMessageService extends Service<typeof CrosschainMessage> 
     }
     const poolIds = Array.from(poolIdSet);
     const tokenIds = Array.from(tokenIdSet);
-    if (poolIds.length > 1) throw new Error("Multiple pools found among messages");
+    if (poolIds.length > 1) {
+      serviceError("Multiple pools found among messages");
+      return [null, null];
+    }
     return [poolIds.pop() ?? null, tokenIds.pop() ?? null];
   }
 

--- a/src/services/HoldingService.ts
+++ b/src/services/HoldingService.ts
@@ -44,8 +44,8 @@ export class HoldingService extends Service<typeof Holding> {
    */
   public increase(amount: bigint, increaseValue: bigint) {
     const { assetQuantity, totalValue } = this.data;
-    this.data.assetQuantity! = assetQuantity ?? 0n + amount;
-    this.data.totalValue! = totalValue ?? 0n + increaseValue;
+    this.data.assetQuantity = assetQuantity ?? 0n + amount;
+    this.data.totalValue = totalValue ?? 0n + increaseValue;
     return this;
   }
 
@@ -60,8 +60,8 @@ export class HoldingService extends Service<typeof Holding> {
    */
   public decrease(amount: bigint, decreaseValue: bigint) {
     const { assetQuantity, totalValue } = this.data;
-    this.data.assetQuantity! = assetQuantity ?? 0n - amount;
-    this.data.totalValue! = totalValue ?? 0n - decreaseValue;
+    this.data.assetQuantity = assetQuantity ?? 0n - amount;
+    this.data.totalValue = totalValue ?? 0n - decreaseValue;
     return this;
   }
 

--- a/src/services/HoldingService.ts
+++ b/src/services/HoldingService.ts
@@ -44,11 +44,8 @@ export class HoldingService extends Service<typeof Holding> {
    */
   public increase(amount: bigint, increaseValue: bigint) {
     const { assetQuantity, totalValue } = this.data;
-    if (assetQuantity === null || totalValue === null) {
-      throw new Error("Hub asset amount or value is null");
-    }
-    this.data.assetQuantity! += amount;
-    this.data.totalValue! += increaseValue;
+    this.data.assetQuantity! = assetQuantity ?? 0n + amount;
+    this.data.totalValue! = totalValue ?? 0n + increaseValue;
     return this;
   }
 
@@ -63,11 +60,8 @@ export class HoldingService extends Service<typeof Holding> {
    */
   public decrease(amount: bigint, decreaseValue: bigint) {
     const { assetQuantity, totalValue } = this.data;
-    if (assetQuantity === null || totalValue === null) {
-      throw new Error("Hub asset amount or value is null");
-    }
-    this.data.assetQuantity! -= amount;
-    this.data.totalValue! -= decreaseValue;
+    this.data.assetQuantity! = assetQuantity ?? 0n - amount;
+    this.data.totalValue! = totalValue ?? 0n - decreaseValue;
     return this;
   }
 
@@ -81,10 +75,7 @@ export class HoldingService extends Service<typeof Holding> {
    */
   public update(isPositive: boolean, diffValue: bigint) {
     const { totalValue } = this.data;
-    if (totalValue === null) {
-      throw new Error("Hub total value is null");
-    }
-    this.data.totalValue! += isPositive ? diffValue : -diffValue;
+    this.data.totalValue = totalValue ?? 0n + (isPositive ? diffValue : -diffValue);
     return this;
   }
 

--- a/src/services/InvestOrderService.ts
+++ b/src/services/InvestOrderService.ts
@@ -1,7 +1,7 @@
 import type { Event } from "ponder:registry";
 import { Service } from "./Service";
 import { InvestOrder } from "ponder:schema";
-import { serviceLog, addThousandsSeparator } from "../helpers/logger";
+import { serviceLog, addThousandsSeparator, serviceError } from "../helpers/logger";
 import { timestamper } from "../helpers/timestamper";
 
 /**
@@ -54,8 +54,14 @@ export class InvestOrderService extends Service<typeof InvestOrder> {
     serviceLog(
       `Issuing shares for investOrder for account ${this.data.account} with navAssetPerShare: ${navAssetPerShare} navPoolPerShare: ${navPoolPerShare}`
     );
-    if (this.data.issuedAt) throw new Error("Shares already issued");
-    if (this.data.approvedAssetsAmount === null) throw new Error("No assets approved");
+    if (this.data.issuedAt) {
+      serviceError("Shares already issued");
+      return this;
+    }
+    if (this.data.approvedAssetsAmount === null) {
+      serviceError("No assets approved");
+      return this;
+    }
 
     this.data = {
       ...this.data,
@@ -86,7 +92,10 @@ export class InvestOrderService extends Service<typeof InvestOrder> {
     serviceLog(
       `Claiming deposit for account ${this.data.account} with claimedSharesAmount: ${claimedSharesAmount} on block ${event.block.number} with timestamp ${event.block.timestamp}`
     );
-    if (this.data.claimedAt) throw new Error("Deposit already claimed");
+    if (this.data.claimedAt) {
+      serviceError("Deposit already claimed");
+      return this;
+    }
     if (paymentAssetAmount !== this.data.approvedAssetsAmount)
       serviceLog(
         `paymentAssetAmount ${addThousandsSeparator(paymentAssetAmount)} !== ${addThousandsSeparator(this.data.approvedAssetsAmount ?? 0n)} approvedAssetsAmount`

--- a/src/services/PoolAdapterService.ts
+++ b/src/services/PoolAdapterService.ts
@@ -221,7 +221,8 @@ export class PoolAdapterService extends Service<typeof PoolAdapter> {
     for (let i = 0; i < adapterCount; i++) {
       const word = hex.slice(offset, offset + 64);
       if (word.length !== 64) {
-        throw new Error(`Invalid adapterList length for adapter index ${i}`);
+        serviceError(`Invalid adapterList length for adapter index ${i}`);
+        return [];
       }
       addresses.push(formatBytes32ToAddress(`0x${word}`));
       offset += 64;

--- a/src/services/RedeemOrderService.ts
+++ b/src/services/RedeemOrderService.ts
@@ -1,7 +1,7 @@
 import type { Event } from "ponder:registry";
 import { Service } from "./Service";
 import { RedeemOrder } from "ponder:schema";
-import { serviceLog, addThousandsSeparator } from "../helpers/logger";
+import { serviceLog, addThousandsSeparator, serviceError } from "../helpers/logger";
 import { timestamper } from "../helpers/timestamper";
 
 /**
@@ -59,8 +59,14 @@ export class RedeemOrderService extends Service<typeof RedeemOrder> {
       `Revoking shares for account ${this.data.account} with navAssetPerShare: ${navAssetPerShare} navPoolPerShare: ${navPoolPerShare} shareDecimals: ${shareDecimals} on block ${event.block.number} and timestamp ${event.block.timestamp}`
     );
     const poolDecimals = shareDecimals;
-    if (this.data.revokedAt) throw new Error("Shares already revoked");
-    if (this.data.approvedSharesAmount === null) throw new Error("No shares approved");
+    if (this.data.revokedAt) {
+      serviceError("Shares already revoked");
+      return this;
+    }
+    if (this.data.approvedSharesAmount === null) {
+      serviceError("No shares approved");
+      return this;
+    }
     this.data = {
       ...this.data,
       ...timestamper("revoked", event),
@@ -97,7 +103,10 @@ export class RedeemOrderService extends Service<typeof RedeemOrder> {
     serviceLog(
       `Claiming redeem for account ${this.data.account} with claimedAssetsAmount: ${claimedAssetsAmount} on block ${event.block.number} and timestamp ${event.block.timestamp}`
     );
-    if (this.data.claimedAt) throw new Error("Redeem already claimed");
+    if (this.data.claimedAt) {
+      serviceError("Redeem already claimed");
+      return this;
+    }
     if (paymentShareAmount !== this.data.approvedSharesAmount)
       serviceLog(
         `paymentShareAmount ${addThousandsSeparator(paymentShareAmount)} !== ${addThousandsSeparator(this.data.approvedSharesAmount ?? 0n)} approvedSharesAmount`

--- a/src/services/TokenInstanceService.ts
+++ b/src/services/TokenInstanceService.ts
@@ -73,11 +73,8 @@ export class TokenInstanceService extends Service<typeof TokenInstance> {
    * @throws {Error} When total issuance is not set (null)
    */
   public increaseTotalIssuance(tokenAmount: bigint) {
-    if (this.data.totalIssuance === null)
-      throw new Error(
-        `Total issuance for token ${this.data.centrifugeId}-${this.data.tokenId} is not set`
-      );
-    this.data.totalIssuance += tokenAmount;
+    const { totalIssuance } = this.data;
+    this.data.totalIssuance = totalIssuance ?? 0n + tokenAmount;
     serviceLog(
       `Increased totalIssuance for token ${this.data.centrifugeId}-${this.data.tokenId} by ${tokenAmount} to ${this.data.totalIssuance}`
     );
@@ -92,11 +89,8 @@ export class TokenInstanceService extends Service<typeof TokenInstance> {
    * @throws {Error} When total issuance is not set (null)
    */
   public decreaseTotalIssuance(tokenAmount: bigint) {
-    if (this.data.totalIssuance === null)
-      throw new Error(
-        `Total issuance for token ${this.data.centrifugeId}-${this.data.tokenId} is not set`
-      );
-    this.data.totalIssuance -= tokenAmount;
+    const { totalIssuance } = this.data;
+    this.data.totalIssuance = totalIssuance ?? 0n - tokenAmount;
     serviceLog(
       `Decreased totalIssuance for token ${this.data.centrifugeId}-${this.data.tokenId} by ${tokenAmount} to ${this.data.totalIssuance}`
     );

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -113,9 +113,8 @@ export class TokenService extends Service<typeof Token> {
    * @throws {Error} When totalIssuance is null (not initialized)
    */
   public increaseTotalIssuance(tokenAmount: bigint) {
-    if (this.data.totalIssuance === null)
-      throw new Error(`totalIssuance for token ${this.data.id} is not set`);
-    this.data.totalIssuance += tokenAmount;
+    const { totalIssuance } = this.data;
+    this.data.totalIssuance = totalIssuance ?? 0n + tokenAmount;
     serviceLog(
       `Increased totalIssuance for token ${this.data.id} by ${tokenAmount} to ${this.data.totalIssuance}`
     );
@@ -130,9 +129,8 @@ export class TokenService extends Service<typeof Token> {
    * @throws {Error} When totalIssuance is null (not initialized)
    */
   public decreaseTotalIssuance(tokenAmount: bigint) {
-    if (this.data.totalIssuance === null)
-      throw new Error(`totalIssuance for token ${this.data.id} is not set`);
-    this.data.totalIssuance -= tokenAmount;
+    const { totalIssuance } = this.data;
+    this.data.totalIssuance = totalIssuance ?? 0n - tokenAmount;
     serviceLog(
       `Decreased totalIssuance for token ${this.data.id} by ${tokenAmount} to ${this.data.totalIssuance}`
     );


### PR DESCRIPTION
### TL;DR

This branch stops using `throw new Error(...)` in several indexer entity services so unexpected or duplicate state does **not** abort Ponder indexing. Guard paths now call **`serviceError`** (where logging on failure matters) and **return early** with no-op semantics, or return **neutral values** (`[]`, `[null, null]`) so handlers can continue. **`HoldingService`**, **`TokenService`**, and **`TokenInstanceService`** replace “null means error” throws with **null-coalescing to `0n`** before applying deltas to quantities/issuance.

---

### Context (Why)

- **Problem:** Throwing from service methods bubbles up and can **fail entire event / block processing** for data that is often better treated as **loggable inconsistency** (duplicate issue/claim, malformed adapter list, ambiguous cross-chain pool id) or as **recoverable defaults** (null aggregates treated as zero before applying a delta).
- **Impact without this change:** A single bad log or edge case can **stall or crash the indexer** instead of degrading gracefully with a logged error and a defined in-memory outcome.

---

### Implementation (How)

| Area | Change |
| :--- | :--- |
| **`InvestOrderService` / `RedeemOrderService`** | “Already issued/revoked/claimed” and “no approved amount” no longer throw; they **`serviceError(...)`** and **`return this`** without mutating state. |
| **`CrosschainMessageService`** | Multiple pool ids among messages: **`serviceError`**, then return **`[null, null]`** instead of throwing. |
| **`PoolAdapterService`** | Invalid `adapterList` slice length: **`serviceError`**, return **`[]`**. |
| **`HoldingService`** | Removed throws on null `assetQuantity` / `totalValue`; assignments use **`?? 0n`** combined with **`+`/`-`** (see **Risk**). |
| **`TokenService` / `TokenInstanceService`** | Same pattern for **`increaseTotalIssuance` / `decreaseTotalIssuance`**: no throw when `totalIssuance` is null; use **`?? 0n`** with arithmetic. |
| **Docs** | Several JSDoc `@throws` lines are now **stale** for **Holding**, **Token**, and **TokenInstance** (still claim throw on null). |

Architecturally, this aligns “soft” failures with **`serviceError`** (errors still surface in logs where configured) while keeping the sync path **non-throwing**—consistent with **`AGENTS.md`** guidance that **`serviceError` still logs** under Ponder.

---

### Evidence of Quality (Testing)

- **Automated:** No test file changes in the current diff.
- **Manual / project rules (author should run before merge):**
  - Ensure **mainnet** `.env.local` and run **`pnpm update-registry`**, then **`pnpm typecheck`** and **`pnpm lint`** per repo rules.
- **Visuals:** N/A (indexer/backend only).

---

### Risk & Rollback

- **Risks**
  - **Semantics change:** Duplicate issue/claim/revoke events that used to **stop the world** now **no-op** with an error log—downstream DB state may stay “first writer wins” without a hard failure; confirm that matches product expectations.
  - **Arithmetic + `??` precedence:** Expressions like `assetQuantity ?? 0n + amount` are parsed as `assetQuantity ?? (0n + amount)` because **`+` binds tighter than `??`**. That means when `assetQuantity` / `totalValue` / `totalIssuance` is **non-null**, the **`+ amount` / `- amount` delta is not applied** in the staged code—**reviewers should verify or add parentheses** `(x ?? 0n) + amount` (and analogous for subtraction) **before merging** if the intent is “previous value plus delta.”
  - **Cursor agent file:** If `.cursor/agents/pr-explainer.md` ships, it is **process/docs noise** for production unless the team wants it.

- **Rollback:** Revert the PR or restore prior `throw` behavior in the affected methods; redeploy the previous indexer image/commit if prod is impacted.

---

### Metadata

| Field | Value |
| :--- | :--- |
| **Ticket** | _none in diff_ |
| **Baseline** | **No commits ahead of `origin/main` in this clone;** changes are **staged** vs `765c662` |
| **Breaking changes** | **Unknown** — behavior is softer (no throws); not a GraphQL/schema break by itself |
| **Dependencies** | None in diff |
---