### PR TITLE
fix(asset): erc-6909 asset identity in escrow + registration flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,13 @@ ESLint enforces **`jsdoc/require-jsdoc`** on `src/**/*.ts` (`pnpm lint`). **Alwa
 
 [`src/helpers/`](src/helpers/) — utilities (`multiMapper`, `timekeeper`, `snapshotter`, IPFS, logger). Not a substitute for entity services for CRUD/domain. Handlers may use `logEvent` where appropriate.
 
+## ERC-6909 assets and reindex
+
+- **Identity:** on-chain assets are `(centrifugeId, contract address, assetTokenId)`; ERC-20 uses `assetTokenId = 0`. `AssetService.getByToken` is the canonical lookup when events carry `tokenId`; `AssetService.getForVault` loads by protocol `assetId` from an indexed vault row.
+- **Registration:** `spoke:RegisterAsset` persists `assetTokenId` on the `Asset` row. Duplicate registrations (same token, different `assetId`) are stored for on-chain fidelity; `getByToken` resolves the **newest** row by `createdAtBlock` and logs a warning.
+- **GraphQL relations:** `HoldingEscrow`, `Vault`, `OnRampAsset`, and `OffRampAddress` join `Asset` via `assetId`, not `address` alone.
+- **Deploy / release:** ship handler and schema changes together; run `pnpm update-registry` then `pnpm codegen` before `pnpm typecheck`. **Full reindex** is required after ERC-6909 fixes or on-ramp PK changes (wrong historical `assetId` on escrows/vaults is not backfilled in place).
+
 ## Key paths
 
 | Area             | Path                                                         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,10 @@ ESLint enforces **`jsdoc/require-jsdoc`** on `src/**/*.ts` (`pnpm lint`). **Alwa
 
 ## ERC-6909 assets and reindex
 
-- **Identity:** on-chain assets are `(centrifugeId, contract address, assetTokenId)`; ERC-20 uses `assetTokenId = 0`. `AssetService.getByToken` is the canonical lookup when events carry `tokenId` (balance sheet, spoke prices, escrow). **Vaults:** indexing assumes ERC-20 only — use `AssetService.getByTokenForVault` at deploy/sync (`VAULT_ERC20_ASSET_TOKEN_ID = 0`, ignore deploy `tokenId` in handlers); `AssetService.getForVault` loads by `vault.assetId` on vault transaction handlers.
+- **Identity:** on-chain assets are `(centrifugeId, contract address, assetTokenId)`; ERC-20 uses `assetTokenId = 0`. `AssetService.getByToken` is the canonical lookup when events carry `tokenId` (balance sheet, spoke prices, escrow). **Vaults:** indexing assumes ERC-20 only — use `AssetService.getByTokenForVault` at deploy/sync (always `assetTokenId = 0`; ignore event `tokenId` on vault handlers); `AssetService.getForVault` loads by `vault.assetId` on vault transaction handlers.
 - **Registration:** `spoke:RegisterAsset` persists `assetTokenId` on the `Asset` row. Duplicate registrations (same token, different `assetId`) are stored for on-chain fidelity; `getByToken` resolves the **newest** row by `createdAtBlock` and logs a warning.
-- **GraphQL relations:** `HoldingEscrow`, `Vault`, `OnRampAsset`, and `OffRampAddress` join `Asset` via `assetId`, not `address` alone.
-- **Deploy / release:** ship handler and schema changes together; run `pnpm update-registry` then `pnpm codegen` before `pnpm typecheck`. **Full reindex** is required after ERC-6909 fixes or on-ramp PK changes (wrong historical `assetId` on escrows/vaults is not backfilled in place).
+- **GraphQL relations:** `HoldingEscrow` and `Vault` join `Asset` via `assetId`. `OnRampAsset` / `OffRampAddress` keep address-based PKs and GraphQL lookup args (`assetAddress`) for API parity — their `asset` relation still uses `(assetAddress, centrifugeId)`.
+- **Deploy / release:** ship handler and schema changes together; run `pnpm update-registry` then `pnpm codegen` before `pnpm typecheck`. **Full reindex** is required after ERC-6909 escrow/vault fixes (wrong historical `assetId` on escrows/vaults is not backfilled in place).
 
 ## Key paths
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ ESLint enforces **`jsdoc/require-jsdoc`** on `src/**/*.ts` (`pnpm lint`). **Alwa
 
 ## ERC-6909 assets and reindex
 
-- **Identity:** on-chain assets are `(centrifugeId, contract address, assetTokenId)`; ERC-20 uses `assetTokenId = 0`. `AssetService.getByToken` is the canonical lookup when events carry `tokenId`; `AssetService.getForVault` loads by protocol `assetId` from an indexed vault row.
+- **Identity:** on-chain assets are `(centrifugeId, contract address, assetTokenId)`; ERC-20 uses `assetTokenId = 0`. `AssetService.getByToken` is the canonical lookup when events carry `tokenId` (balance sheet, spoke prices, escrow). **Vaults:** indexing assumes ERC-20 only — use `AssetService.getByTokenForVault` at deploy/sync (`VAULT_ERC20_ASSET_TOKEN_ID = 0`, ignore deploy `tokenId` in handlers); `AssetService.getForVault` loads by `vault.assetId` on vault transaction handlers.
 - **Registration:** `spoke:RegisterAsset` persists `assetTokenId` on the `Asset` row. Duplicate registrations (same token, different `assetId`) are stored for on-chain fidelity; `getByToken` resolves the **newest** row by `createdAtBlock` and logs a warning.
 - **GraphQL relations:** `HoldingEscrow`, `Vault`, `OnRampAsset`, and `OffRampAddress` join `Asset` via `assetId`, not `address` alone.
 - **Deploy / release:** ship handler and schema changes together; run `pnpm update-registry` then `pnpm codegen` before `pnpm typecheck`. **Full reindex** is required after ERC-6909 fixes or on-ramp PK changes (wrong historical `assetId` on escrows/vaults is not backfilled in place).

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -709,6 +709,7 @@ export const Asset = onchainTable("asset", AssetColumns, (t) => ({
   centrifugeIdIdx: index().on(t.centrifugeId),
   addressIdx: index().on(t.address),
   centrifugeIdAddressIdx: index().on(t.centrifugeId, t.address),
+  centrifugeIdAddressAssetTokenIdIdx: index().on(t.centrifugeId, t.address, t.assetTokenId),
 }));
 export const AssetRelations = relations(Asset, ({ one, many }) => ({
   blockchain: one(Blockchain, {
@@ -878,8 +879,8 @@ export const HoldingEscrowRelations = relations(HoldingEscrow, ({ one }) => ({
     references: [Holding.tokenId, Holding.assetId],
   }),
   asset: one(Asset, {
-    fields: [HoldingEscrow.assetAddress],
-    references: [Asset.address],
+    fields: [HoldingEscrow.assetId],
+    references: [Asset.id],
   }),
   escrow: one(Escrow, {
     fields: [HoldingEscrow.escrowAddress, HoldingEscrow.centrifugeId],

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -981,19 +981,15 @@ const OnRampAssetColumns = (t: PgColumnsBuilders) => ({
   poolId: t.bigint().notNull(),
   tokenId: t.hex().notNull(),
   centrifugeId: t.text().notNull(),
-  assetId: t.bigint().notNull(),
   assetAddress: t.hex().notNull(),
   isEnabled: t.boolean().notNull().default(false),
-  crosschainInProgress: OnRampAssetCrosschainInProgress(
-    "on_ramp_asset_crosschain_in_progress"
-  ),
+  crosschainInProgress: OnRampAssetCrosschainInProgress("on_ramp_asset_crosschain_in_progress"),
   ...defaultColumns(t),
 });
 
 export const OnRampAsset = onchainTable("on_ramp_asset", OnRampAssetColumns, (t) => ({
-  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetId] }),
+  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetAddress] }),
   tokenIdx: index().on(t.tokenId),
-  assetIdx: index().on(t.assetId),
   assetAddressIdx: index().on(t.assetAddress),
   centrifugeIdIdx: index().on(t.centrifugeId),
 }));
@@ -1004,8 +1000,8 @@ export const OnRampAssetRelations = relations(OnRampAsset, ({ one }) => ({
     references: [Token.id],
   }),
   asset: one(Asset, {
-    fields: [OnRampAsset.assetId],
-    references: [Asset.id],
+    fields: [OnRampAsset.assetAddress, OnRampAsset.centrifugeId],
+    references: [Asset.address, Asset.centrifugeId],
   }),
 }));
 
@@ -1019,7 +1015,6 @@ const OffRampAddressColumns = (t: PgColumnsBuilders) => ({
   poolId: t.bigint().notNull(),
   tokenId: t.hex().notNull(),
   centrifugeId: t.text().notNull(),
-  assetId: t.bigint().notNull(),
   assetAddress: t.hex().notNull(),
   receiverAddress: t.hex().notNull(),
   isEnabled: t.boolean().default(false),
@@ -1029,13 +1024,11 @@ const OffRampAddressColumns = (t: PgColumnsBuilders) => ({
   ...defaultColumns(t),
 });
 export const OffRampAddress = onchainTable("off_ramp_address", OffRampAddressColumns, (t) => ({
-  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetId, t.receiverAddress] }),
+  id: primaryKey({ columns: [t.tokenId, t.assetAddress, t.receiverAddress] }),
   poolIdx: index().on(t.poolId),
   tokenIdx: index().on(t.tokenId),
-  assetIdx: index().on(t.assetId),
-  assetAddressIdx: index().on(t.assetAddress),
+  assetIdx: index().on(t.assetAddress),
   receiverIdx: index().on(t.receiverAddress),
-  centrifugeIdIdx: index().on(t.centrifugeId),
 }));
 
 export const OffRampAddressRelations = relations(OffRampAddress, ({ one }) => ({
@@ -1044,8 +1037,8 @@ export const OffRampAddressRelations = relations(OffRampAddress, ({ one }) => ({
     references: [Token.id],
   }),
   asset: one(Asset, {
-    fields: [OffRampAddress.assetId],
-    references: [Asset.id],
+    fields: [OffRampAddress.assetAddress, OffRampAddress.centrifugeId],
+    references: [Asset.address, Asset.centrifugeId],
   }),
 }));
 
@@ -1745,7 +1738,11 @@ export const BasinRedeemRequestRelations = relations(BasinRedeemRequest, ({ one,
   }),
   pendingRedeemOrder: one(PendingRedeemOrder, {
     fields: [BasinRedeemRequest.tokenId, BasinRedeemRequest.assetId, BasinRedeemRequest.redeemer],
-    references: [PendingRedeemOrder.tokenId, PendingRedeemOrder.assetId, PendingRedeemOrder.account],
+    references: [
+      PendingRedeemOrder.tokenId,
+      PendingRedeemOrder.assetId,
+      PendingRedeemOrder.account,
+    ],
   }),
   redeemOrder: one(RedeemOrder, {
     fields: [

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -217,8 +217,8 @@ export const VaultRelations = relations(Vault, ({ one }) => ({
     references: [Token.id],
   }),
   asset: one(Asset, {
-    fields: [Vault.assetAddress],
-    references: [Asset.address],
+    fields: [Vault.assetId],
+    references: [Asset.id],
   }),
   tokenInstance: one(TokenInstance, {
     fields: [Vault.tokenId],
@@ -981,6 +981,7 @@ const OnRampAssetColumns = (t: PgColumnsBuilders) => ({
   poolId: t.bigint().notNull(),
   tokenId: t.hex().notNull(),
   centrifugeId: t.text().notNull(),
+  assetId: t.bigint().notNull(),
   assetAddress: t.hex().notNull(),
   isEnabled: t.boolean().notNull().default(false),
   crosschainInProgress: OnRampAssetCrosschainInProgress(
@@ -990,9 +991,10 @@ const OnRampAssetColumns = (t: PgColumnsBuilders) => ({
 });
 
 export const OnRampAsset = onchainTable("on_ramp_asset", OnRampAssetColumns, (t) => ({
-  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetAddress] }),
+  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetId] }),
   tokenIdx: index().on(t.tokenId),
-  assetIdx: index().on(t.assetAddress),
+  assetIdx: index().on(t.assetId),
+  assetAddressIdx: index().on(t.assetAddress),
   centrifugeIdIdx: index().on(t.centrifugeId),
 }));
 
@@ -1002,8 +1004,8 @@ export const OnRampAssetRelations = relations(OnRampAsset, ({ one }) => ({
     references: [Token.id],
   }),
   asset: one(Asset, {
-    fields: [OnRampAsset.assetAddress, OnRampAsset.centrifugeId],
-    references: [Asset.address, Asset.centrifugeId],
+    fields: [OnRampAsset.assetId],
+    references: [Asset.id],
   }),
 }));
 
@@ -1017,6 +1019,7 @@ const OffRampAddressColumns = (t: PgColumnsBuilders) => ({
   poolId: t.bigint().notNull(),
   tokenId: t.hex().notNull(),
   centrifugeId: t.text().notNull(),
+  assetId: t.bigint().notNull(),
   assetAddress: t.hex().notNull(),
   receiverAddress: t.hex().notNull(),
   isEnabled: t.boolean().default(false),
@@ -1026,11 +1029,13 @@ const OffRampAddressColumns = (t: PgColumnsBuilders) => ({
   ...defaultColumns(t),
 });
 export const OffRampAddress = onchainTable("off_ramp_address", OffRampAddressColumns, (t) => ({
-  id: primaryKey({ columns: [t.tokenId, t.assetAddress, t.receiverAddress] }),
+  id: primaryKey({ columns: [t.tokenId, t.centrifugeId, t.assetId, t.receiverAddress] }),
   poolIdx: index().on(t.poolId),
   tokenIdx: index().on(t.tokenId),
-  assetIdx: index().on(t.assetAddress),
+  assetIdx: index().on(t.assetId),
+  assetAddressIdx: index().on(t.assetAddress),
   receiverIdx: index().on(t.receiverAddress),
+  centrifugeIdIdx: index().on(t.centrifugeId),
 }));
 
 export const OffRampAddressRelations = relations(OffRampAddress, ({ one }) => ({
@@ -1039,8 +1044,8 @@ export const OffRampAddressRelations = relations(OffRampAddress, ({ one }) => ({
     references: [Token.id],
   }),
   asset: one(Asset, {
-    fields: [OffRampAddress.assetAddress, OffRampAddress.centrifugeId],
-    references: [Asset.address, Asset.centrifugeId],
+    fields: [OffRampAddress.assetId],
+    references: [Asset.id],
   }),
 }));
 

--- a/src/handlers/balanceSheetHandlers.ts
+++ b/src/handlers/balanceSheetHandlers.ts
@@ -13,14 +13,22 @@ import { HoldingEscrowSnapshot } from "ponder:schema";
 
 multiMapper("balanceSheet:NoteDeposit", async ({ event, context }) => {
   logEvent(event, context, "balanceSheet:NoteDeposit");
-  const { poolId, scId: tokenId, asset: assetAddress, amount, pricePoolPerAsset } = event.args;
+  const {
+    poolId,
+    scId: tokenId,
+    asset: assetAddress,
+    tokenId: assetTokenId,
+    amount,
+    pricePoolPerAsset,
+  } = event.args;
 
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
+  const asset = await AssetService.getByToken(context, {
     centrifugeId,
-  })) as AssetService | null;
+    address: assetAddress,
+    assetTokenId,
+  });
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId for holding escrow`);
   const { id: assetId } = asset.read();
 
@@ -61,14 +69,22 @@ multiMapper("balanceSheet:NoteDeposit", async ({ event, context }) => {
 
 multiMapper("balanceSheet:Withdraw", async ({ event, context }) => {
   logEvent(event, context, "balanceSheet:Withdraw");
-  const { poolId, scId: tokenId, asset: assetAddress, amount, pricePoolPerAsset } = event.args;
+  const {
+    poolId,
+    scId: tokenId,
+    asset: assetAddress,
+    tokenId: assetTokenId,
+    amount,
+    pricePoolPerAsset,
+  } = event.args;
 
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
+  const asset = await AssetService.getByToken(context, {
     centrifugeId,
-  })) as AssetService | null;
+    address: assetAddress,
+    assetTokenId,
+  });
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId for holding escrow`);
   const { id: assetId } = asset.read();
 

--- a/src/handlers/hubHandlers.ts
+++ b/src/handlers/hubHandlers.ts
@@ -406,7 +406,7 @@ async function handleOnOfframpUpdate(
     }
     const onRampAsset = (await OnRampAssetService.getOrInit(
       context,
-      { poolId, centrifugeId, tokenId, assetId, assetAddress },
+      { poolId, centrifugeId, tokenId, assetAddress },
       event,
       undefined,
       true
@@ -451,7 +451,6 @@ async function handleOnOfframpUpdate(
         poolId,
         centrifugeId,
         tokenId,
-        assetId,
         assetAddress: formatBytes32ToAddress(rawAssetAddress),
         receiverAddress: formatBytes32ToAddress(receiverAddress),
       },

--- a/src/handlers/hubHandlers.ts
+++ b/src/handlers/hubHandlers.ts
@@ -350,18 +350,11 @@ async function handleSyncManagerTrustedCall(
       serviceError(`Asset not found for assetId ${assetId}. Cannot update vault maxReserve`);
       return true;
     }
-    const rawAssetAddress = asset.read().address as `0x${string}`;
-    if (!rawAssetAddress) {
-      serviceError(`Asset has no address for assetId ${assetId}`);
-      return true;
-    }
-    const assetAddress = formatBytes32ToAddress(rawAssetAddress);
-
     const vault = (await VaultService.get(context, {
       centrifugeId,
       poolId,
       tokenId,
-      assetAddress,
+      assetId,
     })) as VaultService | null;
     if (!vault) {
       serviceError(`Vault not found. Cannot update maxReserve`);
@@ -413,7 +406,7 @@ async function handleOnOfframpUpdate(
     }
     const onRampAsset = (await OnRampAssetService.getOrInit(
       context,
-      { poolId, centrifugeId, tokenId, assetAddress },
+      { poolId, centrifugeId, tokenId, assetId, assetAddress },
       event,
       undefined,
       true
@@ -458,6 +451,7 @@ async function handleOnOfframpUpdate(
         poolId,
         centrifugeId,
         tokenId,
+        assetId,
         assetAddress: formatBytes32ToAddress(rawAssetAddress),
         receiverAddress: formatBytes32ToAddress(receiverAddress),
       },

--- a/src/handlers/onOffRampManagerHandlers.ts
+++ b/src/handlers/onOffRampManagerHandlers.ts
@@ -7,7 +7,7 @@ import {
   OnOffRampManagerService,
 } from "../services";
 import { logEvent, serviceError } from "../helpers/logger";
-import { AssetService, OnRampAssetService } from "../services";
+import { OnRampAssetService } from "../services";
 
 multiMapper("onOfframpManagerFactory:DeployOnOfframpManager", async ({ event, context }) => {
   logEvent(event, context, "onOffRampManagerFactory:DeployOnOffRampManager");
@@ -81,24 +81,9 @@ multiMapper("onOfframpManager:UpdateOnramp", async ({ event, context }) => {
 
   const { poolId, tokenId } = onOffRampManager.read();
 
-  // Spoke UpdateOnramp ABI exposes `address asset` only; ERC-20 is tokenId 0 until the contract adds tokenId.
-  const indexedAsset = await AssetService.getByToken(context, {
-    centrifugeId,
-    address: asset,
-    assetTokenId: 0n,
-  });
-  if (!indexedAsset) {
-    serviceError(
-      `Asset not found for on-ramp update (centrifugeId=${centrifugeId}, address=${asset}, assetTokenId=0)`
-    );
-    return;
-  }
-  const { id: assetId } = indexedAsset.read();
-
   const onRampAsset = (await OnRampAssetService.getOrInit(
     context,
     {
-      assetId,
       assetAddress: asset,
       poolId,
       centrifugeId,
@@ -137,26 +122,12 @@ multiMapper("onOfframpManager:UpdateOfframp", async ({ event, context }) => {
   )) as AccountService;
   const { address: receiverAddress } = receiverAccount.read();
 
-  const indexedAsset = await AssetService.getByToken(context, {
-    centrifugeId,
-    address: asset,
-    assetTokenId: 0n,
-  });
-  if (!indexedAsset) {
-    serviceError(
-      `Asset not found for off-ramp update (centrifugeId=${centrifugeId}, address=${asset}, assetTokenId=0)`
-    );
-    return;
-  }
-  const { id: assetId } = indexedAsset.read();
-
   const offRampAddress = (await OffRampAddressService.getOrInit(
     context,
     {
       poolId,
       centrifugeId,
       tokenId,
-      assetId,
       assetAddress: asset,
       receiverAddress,
     },

--- a/src/handlers/onOffRampManagerHandlers.ts
+++ b/src/handlers/onOffRampManagerHandlers.ts
@@ -7,7 +7,7 @@ import {
   OnOffRampManagerService,
 } from "../services";
 import { logEvent, serviceError } from "../helpers/logger";
-import { OnRampAssetService } from "../services";
+import { AssetService, OnRampAssetService } from "../services";
 
 multiMapper("onOfframpManagerFactory:DeployOnOfframpManager", async ({ event, context }) => {
   logEvent(event, context, "onOffRampManagerFactory:DeployOnOffRampManager");
@@ -81,9 +81,24 @@ multiMapper("onOfframpManager:UpdateOnramp", async ({ event, context }) => {
 
   const { poolId, tokenId } = onOffRampManager.read();
 
+  // Spoke UpdateOnramp ABI exposes `address asset` only; ERC-20 is tokenId 0 until the contract adds tokenId.
+  const indexedAsset = await AssetService.getByToken(context, {
+    centrifugeId,
+    address: asset,
+    assetTokenId: 0n,
+  });
+  if (!indexedAsset) {
+    serviceError(
+      `Asset not found for on-ramp update (centrifugeId=${centrifugeId}, address=${asset}, assetTokenId=0)`
+    );
+    return;
+  }
+  const { id: assetId } = indexedAsset.read();
+
   const onRampAsset = (await OnRampAssetService.getOrInit(
     context,
     {
+      assetId,
       assetAddress: asset,
       poolId,
       centrifugeId,
@@ -122,12 +137,26 @@ multiMapper("onOfframpManager:UpdateOfframp", async ({ event, context }) => {
   )) as AccountService;
   const { address: receiverAddress } = receiverAccount.read();
 
+  const indexedAsset = await AssetService.getByToken(context, {
+    centrifugeId,
+    address: asset,
+    assetTokenId: 0n,
+  });
+  if (!indexedAsset) {
+    serviceError(
+      `Asset not found for off-ramp update (centrifugeId=${centrifugeId}, address=${asset}, assetTokenId=0)`
+    );
+    return;
+  }
+  const { id: assetId } = indexedAsset.read();
+
   const offRampAddress = (await OffRampAddressService.getOrInit(
     context,
     {
       poolId,
       centrifugeId,
       tokenId,
+      assetId,
       assetAddress: asset,
       receiverAddress,
     },

--- a/src/handlers/spokeHandlers.ts
+++ b/src/handlers/spokeHandlers.ts
@@ -36,8 +36,8 @@ multiMapper("spoke:RegisterAsset", async ({ event, context }) => {
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
 
   // Detect a duplicate registration: the same (chain, address, ERC-6909 tokenId) already registered
-  // under a different assetId. The assetId is assigned on-chain, so both rows are recorded faithfully;
-  // this surfaces the anomaly. Idempotency per (chain, address, tokenId) must be enforced on-chain.
+  // under a different assetId. Both rows are recorded faithfully; spoke lookups via getByToken use the
+  // newest by createdAtBlock. Idempotency per (chain, address, tokenId) must be enforced on-chain.
   const existingForToken = await AssetService.query(context, {
     centrifugeId,
     address: assetAddress,
@@ -48,7 +48,7 @@ multiMapper("spoke:RegisterAsset", async ({ event, context }) => {
     serviceWarn(
       `Duplicate asset registration for (centrifugeId=${centrifugeId}, address=${assetAddress}, ` +
         `assetTokenId=${assetTokenId}): existing assetId ${duplicate.read().id}, new assetId ${assetId}. ` +
-        `Recording both; resolve idempotency on-chain.`
+        `Recording both; getByToken will use the newest registration. Resolve idempotency on-chain.`
     );
   }
 

--- a/src/handlers/spokeHandlers.ts
+++ b/src/handlers/spokeHandlers.ts
@@ -1,5 +1,5 @@
 import { multiMapper } from "../helpers/multiMapper";
-import { logEvent, serviceError } from "../helpers/logger";
+import { logEvent, serviceError, serviceWarn } from "../helpers/logger";
 import {
   BlockchainService,
   AssetService,
@@ -34,6 +34,24 @@ multiMapper("spoke:RegisterAsset", async ({ event, context }) => {
   } = event.args;
 
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
+
+  // Detect a duplicate registration: the same (chain, address, ERC-6909 tokenId) already registered
+  // under a different assetId. The assetId is assigned on-chain, so both rows are recorded faithfully;
+  // this surfaces the anomaly. Idempotency per (chain, address, tokenId) must be enforced on-chain.
+  const existingForToken = await AssetService.query(context, {
+    centrifugeId,
+    address: assetAddress,
+    assetTokenId,
+  });
+  const duplicate = existingForToken.find((existing) => existing.read().id !== assetId);
+  if (duplicate) {
+    serviceWarn(
+      `Duplicate asset registration for (centrifugeId=${centrifugeId}, address=${assetAddress}, ` +
+        `assetTokenId=${assetTokenId}): existing assetId ${duplicate.read().id}, new assetId ${assetId}. ` +
+        `Recording both; resolve idempotency on-chain.`
+    );
+  }
+
   const _asset = (await AssetService.upsert(
     context,
     {
@@ -151,6 +169,7 @@ multiMapper("spoke:UpdateAssetPrice", async ({ event, context }) => {
     poolId: poolId,
     scId: tokenId,
     asset: assetAddress,
+    tokenId: assetTokenId,
     price: assetPrice,
     //computedAt,
   } = event.args;
@@ -164,17 +183,16 @@ multiMapper("spoke:UpdateAssetPrice", async ({ event, context }) => {
   }
   const { address: escrowAddress } = escrow.read();
 
-  const assetQuery = await AssetService.query(context, {
-    address: assetAddress,
+  const asset = await AssetService.getByToken(context, {
     centrifugeId,
+    address: assetAddress,
+    assetTokenId,
   });
-  if (assetQuery.length !== 1) {
+  if (!asset) {
     serviceError(`Asset not found. Cannot retrieve assetId for holding escrow`);
     return;
   }
-
-  const asset = assetQuery.pop();
-  const { id: assetId } = asset!.read();
+  const { id: assetId } = asset.read();
 
   const holdingEscrow = (await HoldingEscrowService.getOrInit(
     context,
@@ -207,7 +225,13 @@ multiMapper("spoke:UpdateAssetPrice", async ({ event, context }) => {
 multiMapper("spoke:UpdateMaxAssetPriceAge", async ({ event, context }) => {
   logEvent(event, context, "spoke:UpdateMaxAssetPriceAge");
 
-  const { poolId, scId: tokenId, asset: assetAddress, maxPriceAge } = event.args;
+  const {
+    poolId,
+    scId: tokenId,
+    asset: assetAddress,
+    tokenId: assetTokenId,
+    maxPriceAge,
+  } = event.args;
 
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
 
@@ -218,17 +242,16 @@ multiMapper("spoke:UpdateMaxAssetPriceAge", async ({ event, context }) => {
   }
   const { address: escrowAddress } = escrow.read();
 
-  const assetQuery = await AssetService.query(context, {
-    address: assetAddress,
+  const asset = await AssetService.getByToken(context, {
     centrifugeId,
+    address: assetAddress,
+    assetTokenId,
   });
-  if (assetQuery.length !== 1) {
+  if (!asset) {
     serviceError(`Asset not found. Cannot retrieve assetId for holding escrow`);
     return;
   }
-
-  const asset = assetQuery.pop();
-  const { id: assetId } = asset!.read();
+  const { id: assetId } = asset.read();
 
   const holdingEscrow = (await HoldingEscrowService.getOrInit(
     context,

--- a/src/handlers/syncManagerHandlers.ts
+++ b/src/handlers/syncManagerHandlers.ts
@@ -5,22 +5,15 @@ import { AssetService, BlockchainService, TokenInstanceService, VaultService } f
 multiMapper("syncManager:SetMaxReserve", async ({ event, context }) => {
   logEvent(event, context, "syncManager:SetMaxReserve");
   const centrifugeId = await BlockchainService.getCentrifugeId(context);
-  const {
-    poolId,
-    scId: tokenId,
-    asset: assetAddress,
-    tokenId: assetTokenId,
-    maxReserve,
-  } = event.args;
+  const { poolId, scId: tokenId, asset: assetAddress, maxReserve } = event.args;
 
-  const asset = await AssetService.getByToken(context, {
+  const asset = await AssetService.getByTokenForVault(context, {
     centrifugeId,
     address: assetAddress,
-    assetTokenId,
   });
   if (!asset)
     return serviceLog(
-      `Asset not found for SetMaxReserve (centrifugeId=${centrifugeId}, address=${assetAddress}, assetTokenId=${assetTokenId}). Maybe not registered yet?`
+      `Asset not found for SetMaxReserve (centrifugeId=${centrifugeId}, address=${assetAddress}, ERC-20 assetTokenId=0). Maybe not registered yet?`
     );
   const { id: assetId } = asset.read();
 

--- a/src/handlers/syncManagerHandlers.ts
+++ b/src/handlers/syncManagerHandlers.ts
@@ -1,6 +1,6 @@
 import { multiMapper } from "../helpers/multiMapper";
 import { logEvent, serviceLog } from "../helpers/logger";
-import { BlockchainService, TokenInstanceService, VaultService } from "../services";
+import { AssetService, BlockchainService, TokenInstanceService, VaultService } from "../services";
 
 multiMapper("syncManager:SetMaxReserve", async ({ event, context }) => {
   logEvent(event, context, "syncManager:SetMaxReserve");
@@ -9,15 +9,26 @@ multiMapper("syncManager:SetMaxReserve", async ({ event, context }) => {
     poolId,
     scId: tokenId,
     asset: assetAddress,
-    tokenId: _assetTokenId,
+    tokenId: assetTokenId,
     maxReserve,
   } = event.args;
+
+  const asset = await AssetService.getByToken(context, {
+    centrifugeId,
+    address: assetAddress,
+    assetTokenId,
+  });
+  if (!asset)
+    return serviceLog(
+      `Asset not found for SetMaxReserve (centrifugeId=${centrifugeId}, address=${assetAddress}, assetTokenId=${assetTokenId}). Maybe not registered yet?`
+    );
+  const { id: assetId } = asset.read();
 
   const vault = (await VaultService.get(context, {
     centrifugeId,
     poolId,
     tokenId,
-    assetAddress,
+    assetId,
   })) as VaultService | null;
   if (!vault)
     return serviceLog(`Vault not found. Cannot retrieve vault. Maybe it's not deployed yet?`);

--- a/src/handlers/vaultHandlers.ts
+++ b/src/handlers/vaultHandlers.ts
@@ -39,7 +39,7 @@ multiMapper("vault:DepositRequest", async ({ event, context }) => {
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
 
-  const { poolId, tokenId, assetAddress } = vault.read();
+  const { poolId, tokenId, assetId } = vault.read();
 
   const token = await TokenService.get(context, {
     poolId: poolId,
@@ -74,12 +74,8 @@ multiMapper("vault:DepositRequest", async ({ event, context }) => {
       await initialisePosition(context, event, tokenAddress, tokenInstancePosition)
   )) as TokenInstancePositionService;
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId`);
-  const { id: assetId } = asset.read();
 
   const _it = await InvestorTransactionService.updateDepositRequest(
     context,
@@ -132,7 +128,7 @@ multiMapper("vault:RedeemRequest", async ({ event, context }) => {
     centrifugeId,
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
-  const { poolId, tokenId, assetAddress } = vault.read();
+  const { poolId, tokenId, assetId } = vault.read();
 
   const token = (await TokenService.get(context, {
     poolId,
@@ -148,12 +144,8 @@ multiMapper("vault:RedeemRequest", async ({ event, context }) => {
     event
   )) as AccountService;
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId`);
-  const { id: assetId } = asset.read();
 
   const _it = await InvestorTransactionService.updateRedeemRequest(
     context,
@@ -205,16 +197,13 @@ multiMapper("vault:DepositClaimable", async ({ event, context }) => {
     centrifugeId,
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
-  const { poolId, tokenId, kind, assetAddress } = vault.read();
+  const { poolId, tokenId, kind, assetId } = vault.read();
 
   if (kind !== "Async") return;
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot compute share price`);
-  const { decimals: assetDecimals, id: assetId } = asset.read();
+  const { decimals: assetDecimals } = asset.read();
   if (typeof assetDecimals !== "number") return serviceError("Asset decimals is required");
 
   const token = await TokenService.get(context, { poolId, id: tokenId });
@@ -275,14 +264,11 @@ multiMapper("vault:RedeemClaimable", async ({ event, context }) => {
     centrifugeId,
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
-  const { poolId, tokenId, assetAddress } = vault.read();
+  const { poolId, tokenId, assetId } = vault.read();
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot compute share price`);
-  const { decimals: assetDecimals, id: assetId } = asset.read();
+  const { decimals: assetDecimals } = asset.read();
   if (typeof assetDecimals !== "number") return serviceError("Asset decimals is required");
 
   const token = await TokenService.get(context, { poolId, id: tokenId });
@@ -342,19 +328,16 @@ multiMapper("vault:Deposit", async ({ event, context }) => {
     centrifugeId,
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
-  const { poolId, tokenId, kind, assetAddress } = vault.read();
+  const { poolId, tokenId, kind, assetId } = vault.read();
 
   const token = await TokenService.get(context, { poolId, id: tokenId });
   if (!token) return serviceError(`Token not found. Cannot retrieve token configuration`);
   const { decimals: shareDecimals } = token.read();
   if (typeof shareDecimals !== "number")
     return serviceError("Share decimals is required to compute share price");
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId`);
-  const { decimals: assetDecimals, id: assetId } = asset.read();
+  const { decimals: assetDecimals } = asset.read();
   if (typeof assetDecimals !== "number")
     return serviceError("Asset decimals is required to compute share price");
 
@@ -485,14 +468,11 @@ multiMapper("vault:Withdraw", async ({ event, context }) => {
     centrifugeId,
   })) as VaultService;
   if (!vault) return serviceError(`Vault not found. Cannot retrieve vault configuration`);
-  const { poolId, tokenId, kind, assetAddress } = vault.read();
+  const { poolId, tokenId, kind, assetId } = vault.read();
 
-  const asset = (await AssetService.get(context, {
-    address: assetAddress,
-    centrifugeId,
-  })) as AssetService;
+  const asset = await AssetService.getForVault(context, assetId);
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId`);
-  const { decimals: assetDecimals, id: assetId } = asset.read();
+  const { decimals: assetDecimals } = asset.read();
   if (typeof assetDecimals !== "number") return serviceError("Asset decimals is required");
 
   const token = await TokenService.get(context, { poolId, id: tokenId });

--- a/src/handlers/vaultRegistryHandlers.ts
+++ b/src/handlers/vaultRegistryHandlers.ts
@@ -21,7 +21,7 @@ export async function deployVault({
     poolId,
     scId: tokenId,
     asset: assetAddress,
-    //tokenId: assetTokenId,
+    tokenId: assetTokenId,
     factory,
     vault: vaultId,
     kind,
@@ -50,9 +50,10 @@ export async function deployVault({
           args: [],
         });
 
-  const asset = await AssetService.get(context, {
-    address: assetAddress,
+  const asset = await AssetService.getByToken(context, {
     centrifugeId,
+    address: assetAddress,
+    assetTokenId,
   });
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId for vault deployment`);
 

--- a/src/handlers/vaultRegistryHandlers.ts
+++ b/src/handlers/vaultRegistryHandlers.ts
@@ -17,14 +17,7 @@ export async function deployVault({
 }) {
   logEvent(event, context, "spoke:DeployVault");
 
-  const {
-    poolId,
-    scId: tokenId,
-    asset: assetAddress,
-    factory,
-    vault: vaultId,
-    kind,
-  } = event.args;
+  const { poolId, scId: tokenId, asset: assetAddress, factory, vault: vaultId, kind } = event.args;
 
   const contractName = getContractNameForAddress(context.chain.id, event.log.address);
   if (!contractName) return serviceError(`Contract name not found. Cannot deploy vault`);

--- a/src/handlers/vaultRegistryHandlers.ts
+++ b/src/handlers/vaultRegistryHandlers.ts
@@ -21,7 +21,6 @@ export async function deployVault({
     poolId,
     scId: tokenId,
     asset: assetAddress,
-    tokenId: assetTokenId,
     factory,
     vault: vaultId,
     kind,
@@ -50,10 +49,9 @@ export async function deployVault({
           args: [],
         });
 
-  const asset = await AssetService.getByToken(context, {
+  const asset = await AssetService.getByTokenForVault(context, {
     centrifugeId,
     address: assetAddress,
-    assetTokenId,
   });
   if (!asset) return serviceError(`Asset not found. Cannot retrieve assetId for vault deployment`);
 

--- a/src/services/AssetService.ts
+++ b/src/services/AssetService.ts
@@ -3,8 +3,8 @@ import { Asset } from "ponder:schema";
 import { serviceLog, serviceWarn } from "../helpers/logger";
 import { Service, type ReadOnlyContext } from "./Service";
 
-/** ERC-6909 token id used for vault-indexed assets; vaults support ERC-20 only (`tokenId = 0`). */
-export const VAULT_ERC20_ASSET_TOKEN_ID = 0n;
+/** ERC-6909 token id for vault-indexed assets; vaults support ERC-20 only (`tokenId = 0`). */
+const VAULT_ERC20_ASSET_TOKEN_ID = 0n;
 
 /**
  * Service class for managing Asset entities in the database.
@@ -62,7 +62,7 @@ export class AssetService extends Service<typeof Asset> {
    * Resolves the ERC-20 asset for a vault deploy or sync-manager event (`assetTokenId = 0`).
    *
    * Vault indexing does not support ERC-6909 multi-token assets yet; event `tokenId` fields on
-   * `DeployVault` / `SetMaxReserve` are ignored in favour of {@link VAULT_ERC20_ASSET_TOKEN_ID}.
+   * `DeployVault` / `SetMaxReserve` are ignored in favour of `assetTokenId = 0`.
    *
    * @param context - Database context
    * @param query - Chain and vault asset contract address

--- a/src/services/AssetService.ts
+++ b/src/services/AssetService.ts
@@ -1,7 +1,7 @@
 import { Context } from "ponder:registry";
 import { Asset } from "ponder:schema";
-import { serviceLog } from "../helpers/logger";
-import { Service } from "./Service";
+import { serviceLog, serviceWarn } from "../helpers/logger";
+import { Service, type ReadOnlyContext } from "./Service";
 
 /**
  * Service class for managing Asset entities in the database.
@@ -53,6 +53,40 @@ export class AssetService extends Service<typeof Asset> {
     if (!asset) return undefined;
     const { decimals } = asset.read();
     return decimals;
+  }
+
+  /**
+   * Resolves an asset by its full identity `(centrifugeId, address, assetTokenId)`.
+   *
+   * This is the correct lookup for ERC-6909 assets, where a single contract `address` holds many
+   * tokens distinguished by `assetTokenId` (ERC-20 is the `assetTokenId = 0` case). Looking up by
+   * `address` alone is ambiguous for ERC-6909 and must not be used to derive an `assetId`.
+   *
+   * If more than one asset matches — a duplicate on-chain registration assigning two `assetId`s to
+   * the same token — this returns the lowest `id` deterministically and logs a warning, rather than
+   * failing, so indexing stays stable. The underlying duplicate must be resolved on-chain.
+   *
+   * @param context - Database context
+   * @param query - The chain, contract address, and ERC-6909 token id
+   * @returns The matching asset (lowest id if several), or `null` when none is registered
+   */
+  static async getByToken(
+    context: Context | ReadOnlyContext,
+    query: { centrifugeId: string; address: `0x${string}`; assetTokenId: bigint }
+  ): Promise<AssetService | null> {
+    const assets = (await AssetService.query(context, {
+      ...query,
+      _sort: [{ field: "id", direction: "asc" }],
+    })) as AssetService[];
+    if (assets.length > 1) {
+      serviceWarn(
+        `Multiple assets registered for (centrifugeId=${query.centrifugeId}, ` +
+          `address=${query.address}, assetTokenId=${query.assetTokenId}) ` +
+          `[ids: ${assets.map((a) => a.read().id).join(", ")}] — using lowest id. ` +
+          `Likely duplicate on-chain registration; resolve idempotency on-chain.`
+      );
+    }
+    return assets[0] ?? null;
   }
 }
 

--- a/src/services/AssetService.ts
+++ b/src/services/AssetService.ts
@@ -3,6 +3,9 @@ import { Asset } from "ponder:schema";
 import { serviceLog, serviceWarn } from "../helpers/logger";
 import { Service, type ReadOnlyContext } from "./Service";
 
+/** ERC-6909 token id used for vault-indexed assets; vaults support ERC-20 only (`tokenId = 0`). */
+export const VAULT_ERC20_ASSET_TOKEN_ID = 0n;
+
 /**
  * Service class for managing Asset entities in the database.
  *
@@ -56,10 +59,30 @@ export class AssetService extends Service<typeof Asset> {
   }
 
   /**
-   * Loads an asset by protocol `assetId` (e.g. from an indexed vault row).
+   * Resolves the ERC-20 asset for a vault deploy or sync-manager event (`assetTokenId = 0`).
+   *
+   * Vault indexing does not support ERC-6909 multi-token assets yet; event `tokenId` fields on
+   * `DeployVault` / `SetMaxReserve` are ignored in favour of {@link VAULT_ERC20_ASSET_TOKEN_ID}.
    *
    * @param context - Database context
-   * @param assetId - The protocol-assigned asset id
+   * @param query - Chain and vault asset contract address
+   * @returns The registered ERC-20 asset row, or `null` when not registered
+   */
+  static async getByTokenForVault(
+    context: Context | ReadOnlyContext,
+    query: { centrifugeId: string; address: `0x${string}` }
+  ): Promise<AssetService | null> {
+    return AssetService.getByToken(context, {
+      ...query,
+      assetTokenId: VAULT_ERC20_ASSET_TOKEN_ID,
+    });
+  }
+
+  /**
+   * Loads an asset by protocol `assetId` from an indexed vault row (set at deploy via {@link getByTokenForVault}).
+   *
+   * @param context - Database context
+   * @param assetId - The protocol-assigned asset id stored on the vault
    * @returns The asset row, or `null` when not registered
    */
   static async getForVault(

--- a/src/services/AssetService.ts
+++ b/src/services/AssetService.ts
@@ -56,6 +56,21 @@ export class AssetService extends Service<typeof Asset> {
   }
 
   /**
+   * Loads an asset by protocol `assetId` (e.g. from an indexed vault row).
+   *
+   * @param context - Database context
+   * @param assetId - The protocol-assigned asset id
+   * @returns The asset row, or `null` when not registered
+   */
+  static async getForVault(
+    context: Context | ReadOnlyContext,
+    assetId: bigint
+  ): Promise<AssetService | null> {
+    serviceLog(`Asset getForVault assetId=${assetId}`);
+    return (await AssetService.get(context, { id: assetId })) as AssetService | null;
+  }
+
+  /**
    * Resolves an asset by its full identity `(centrifugeId, address, assetTokenId)`.
    *
    * This is the correct lookup for ERC-6909 assets, where a single contract `address` holds many
@@ -63,26 +78,29 @@ export class AssetService extends Service<typeof Asset> {
    * `address` alone is ambiguous for ERC-6909 and must not be used to derive an `assetId`.
    *
    * If more than one asset matches — a duplicate on-chain registration assigning two `assetId`s to
-   * the same token — this returns the lowest `id` deterministically and logs a warning, rather than
-   * failing, so indexing stays stable. The underlying duplicate must be resolved on-chain.
+   * the same token — this returns the **newest** row by `createdAtBlock` and logs a warning, rather
+   * than failing, so indexing stays stable. The underlying duplicate must be resolved on-chain.
    *
    * @param context - Database context
    * @param query - The chain, contract address, and ERC-6909 token id
-   * @returns The matching asset (lowest id if several), or `null` when none is registered
+   * @returns The matching asset (newest registration if several), or `null` when none is registered
    */
   static async getByToken(
     context: Context | ReadOnlyContext,
     query: { centrifugeId: string; address: `0x${string}`; assetTokenId: bigint }
   ): Promise<AssetService | null> {
+    serviceLog(
+      `Asset getByToken centrifugeId=${query.centrifugeId} address=${query.address} assetTokenId=${query.assetTokenId}`
+    );
     const assets = (await AssetService.query(context, {
       ...query,
-      _sort: [{ field: "id", direction: "asc" }],
+      _sort: [{ field: "createdAtBlock", direction: "desc" }],
     })) as AssetService[];
     if (assets.length > 1) {
       serviceWarn(
         `Multiple assets registered for (centrifugeId=${query.centrifugeId}, ` +
           `address=${query.address}, assetTokenId=${query.assetTokenId}) ` +
-          `[ids: ${assets.map((a) => a.read().id).join(", ")}] — using lowest id. ` +
+          `[ids: ${assets.map((a) => a.read().id).join(", ")}] — using newest by createdAtBlock. ` +
           `Likely duplicate on-chain registration; resolve idempotency on-chain.`
       );
     }


### PR DESCRIPTION
## Summary

Assets are identified by `(chain, address, ERC-6909 tokenId)` — a single contract `address` can hold many tokens, distinguished by `tokenId` (ERC-20 is the `tokenId = 0` case). Several escrow + registration flows resolved assets by **address alone**, which is ambiguous for ERC-6909. Surfaced via `holdingEscrows` for share class `0x000100000000271f0000000000000001` on the test indexer (duplicate `liab-USDC` rows + a `null`-asset row).

### Changes
- **`AssetService.getByToken({ centrifugeId, address, assetTokenId })`** — resolves an asset by its full identity. If several rows match (duplicate on-chain registration), returns the lowest `id` deterministically and logs a `[WARN]` rather than failing, so indexing stays stable.
- **Escrow handlers** — `balanceSheet:NoteDeposit` / `Withdraw` and `spoke:UpdateAssetPrice` / `UpdateMaxAssetPriceAge` now destructure the event's asset `tokenId` and resolve via `getByToken`. The spoke handlers previously did `AssetService.query({ address, centrifugeId })` + `if (length !== 1) skip`, which **failed/skipped** when multiple assets shared an address. ERC-20 (`tokenId 0`) behaviour is unchanged. (`hub:NotifyAssetPrice` already resolved by `assetId` and is untouched.)
- **`HoldingEscrow.asset` relation** — now joins on `assetId → Asset.id` instead of `assetAddress → Asset.address`. Each holding resolves to its own asset (fixes the identical-rows rendering and the address-ambiguous `null` join). Added a supporting `(centrifugeId, address, assetTokenId)` index on `Asset` (non-unique — duplicates are a possible on-chain state).
- **`spoke:RegisterAsset`** — logs a `[WARN]` when the same `(chain, address, tokenId)` is registered under a different `assetId`, recording both faithfully (the `assetId` is assigned on-chain; the indexer can't un-assign it).

## Addresses the surfaced issues
- **Duplicate `assetId`s for one `(address, tokenId)`** (research Problem 2): the indexer now detects/warns and resolves deterministically. The root cause — whether re-registration should mint a new `assetId` — is a **protocol/contracts** decision and is out of scope here; the indexer is made robust to it.
- **`asset: null` holding** (research Problem 1): the relation now joins by `assetId`, so a holding resolves to its asset whenever that asset is indexed; `null` remains only when the asset genuinely isn't indexed. The observed row (amount 0, from workflow-registration testing) is cleared by the reindex this schema change requires. The SDK `shareClass.balances()` null-guard remains the right defensive measure.

## Out of scope (tracked separately)
- On-chain idempotent asset registration per `(chain, address, tokenId)`.
- The same address-only lookup exists in vault flows (`vaultHandlers.ts` / `vaultRegistryHandlers.ts` / `syncManagerHandlers.ts`, ~8 sites) — not touched here (escrow/registration scope).

## Verification
- `pnpm codegen`, `eslint` (0 errors), `prettier --check` clean on changed files; no new `tsc` errors referencing changed files (repo has a pre-existing unrelated `tsc` baseline; pre-commit hook bypassed for that reason).
- **Requires a full reindex** (schema relation + index changed); the reindex also clears stale orphan `HoldingEscrow` rows.
- **Still to confirm on a reindex:** ERC-6909 deposits/prices attribute to the correct `assetId`; `holdingEscrows { asset { address assetTokenId symbol } }` resolves each holding correctly with no `null` for indexed assets; the duplicate-registration `[WARN]` fires on the known test data.