### PR TITLE
feat(api): adapt quote and status endpoints to LI.FI shape

### DIFF
--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -1,6 +1,5 @@
 import { sValidator } from "@hono/standard-validator";
 import { type Context, Hono } from "hono";
-import { encodeFunctionData } from "viem";
 import * as z from "zod";
 import { getContractAddressForChain, REGISTRY_VERSION_ORDER } from "../contracts";
 import { emptyMessage, MessageType } from "../helpers/messaging";
@@ -90,21 +89,6 @@ const TOKEN_BRIDGE_ADDRESS: Record<number, `0x${string}`> = {
   8453: "0x82a6c7753380f98c093b27c53f86ef6b09c40f49",
 };
 
-const TOKEN_BRIDGE_SEND_ABI = [
-  {
-    type: "function",
-    name: "send",
-    stateMutability: "payable",
-    inputs: [
-      { name: "token", type: "address" },
-      { name: "amount", type: "uint256" },
-      { name: "receiver", type: "bytes32" },
-      { name: "destinationChainId", type: "uint256" },
-      { name: "refundAddress", type: "address" },
-    ],
-    outputs: [{ type: "bytes" }],
-  },
-] as const;
 
 /** Per-chain block explorer tx URL builder; null when the chain isn't mapped. */
 const EXPLORER_TX_BASE: Record<number, string> = {
@@ -365,32 +349,36 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
     decimals: toData.decimals,
   };
 
-  // Executable source-chain call, when the TokenBridge is deployed on the origin and we
-  // know the receiver. Fee is paid in native (value); refund defaults to the receiver.
+  // Uncompiled contract interaction parameters for the TokenBridge `send` call.
+  // Fee is paid in native (value); refund defaults to the receiver.
   const bridgeAddress = TOKEN_BRIDGE_ADDRESS[fromChainId] ?? null;
   const receiver = toAddress ?? fromAddress ?? null;
-  let transactionRequest: {
-    to: `0x${string}`;
-    data: `0x${string}`;
+  let parameters: {
+    contractAddress: `0x${string}`;
+    functionName: string;
     value: string;
     chainId: number;
+    args: {
+      token: string;
+      amount: string;
+      receiver: `0x${string}`;
+      destinationChainId: string;
+      refundAddress: string;
+    };
   } | null = null;
   if (bridgeAddress && receiver) {
-    transactionRequest = {
-      to: bridgeAddress,
-      data: encodeFunctionData({
-        abi: TOKEN_BRIDGE_SEND_ABI,
-        functionName: "send",
-        args: [
-          fromToken as `0x${string}`,
-          fromAmount,
-          addressToBytes32(receiver),
-          BigInt(toChainId),
-          (fromAddress ?? receiver) as `0x${string}`,
-        ],
-      }),
+    parameters = {
+      contractAddress: bridgeAddress,
+      functionName: "send",
       value: totalFee.toString(),
       chainId: fromChainId,
+      args: {
+        token: fromToken,
+        amount: fromAmount.toString(),
+        receiver: addressToBytes32(receiver),
+        destinationChainId: String(toChainId),
+        refundAddress: fromAddress ?? receiver,
+      },
     };
   }
 
@@ -426,7 +414,7 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
         ],
         gasEstimate: estimatedGas,
       },
-      transactionRequest,
+      parameters,
     },
   });
 }
@@ -454,7 +442,7 @@ async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promis
         transactionId: txHashNorm,
         tool: TOOL,
         status: "NOT_FOUND",
-        substatus: "NOT_FOUND",
+        substatus: null,
         substatusMessage: null,
         sending: { txHash: txHashNorm, txLink: null, chainId: null, amount: null, token: null },
         receiving: null,
@@ -555,8 +543,8 @@ async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promis
             txHash: receivingTxHash,
             txLink: explorerTxLink(toChainId, receivingTxHash),
             chainId: toChainId,
-            amount,
-            token: tokenObj ? { ...tokenObj, chainId: toChainId ?? tokenObj.chainId } : null,
+            tokenAddress: tokenObj?.address ?? null,
+            tokenAmount: amount,
             timestamp: toUnix(payload.completedAt ?? payload.deliveredAt),
           }
         : null,

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -424,17 +424,7 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
             included: false,
           },
         ],
-        gasCosts: [
-          {
-            type: "SEND",
-            price: null,
-            estimate: estimatedGas.toString(),
-            limit: estimatedGas.toString(),
-            amount: null,
-            amountUSD: null,
-            token: nativeToken(fromChainId),
-          },
-        ],
+        gasEstimate: estimatedGas,
       },
       transactionRequest,
     },

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -676,8 +676,9 @@ export function createGlacisApp() {
       ] satisfies Route[];
     });
 
+    const bridgeRoutes = routes.filter((r) => TOKEN_BRIDGE_ADDRESS[Number(r.fromChainId)] != null);
     const filteredRoutes =
-      isEnabled === undefined ? routes : routes.filter((r) => r.isEnabled === isEnabled);
+      isEnabled === undefined ? bridgeRoutes : bridgeRoutes.filter((r) => r.isEnabled === isEnabled);
 
     const paginatedRoutes = filteredRoutes.slice(offset, offset + limit);
     const baseUrl = `${requestUrl.origin}${requestUrl.pathname}`;

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -517,7 +517,8 @@ export function createGlacisApp() {
   app.get("/routes", async (c) => {
     const ctx = apiContext(c);
     const ESTIMATED_DURATION = 210; // in seconds
-    const ESTIMATED_GAS = 1000000;
+    const GAS_INITIATE_TRANSFER_SHARES = 369413;
+    const GAS_EXECUTE_TRANSFER_SHARES = 254235;
 
     const tokenInstanceRows = await Services.TokenInstanceService.listAllJoinedWithToken(ctx);
 
@@ -565,7 +566,7 @@ export function createGlacisApp() {
           maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
           decimals: row.token.decimals,
           estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: ESTIMATED_GAS,
+          estimatedGas: GAS_EXECUTE_TRANSFER_SHARES,
           standard: "CentrifugeV31",
         },
         {
@@ -581,7 +582,7 @@ export function createGlacisApp() {
           maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
           decimals: row.token.decimals,
           estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: ESTIMATED_GAS,
+          estimatedGas: GAS_INITIATE_TRANSFER_SHARES,
           standard: "CentrifugeV31",
         },
         // Spoke-to-spoke (2-hop) routes commented out — hub↔spoke only for now.

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -573,7 +573,7 @@ export function createGlacisApp() {
     const requestUrl = new URL(c.req.url);
     const pagingIncludesIsEnabled = requestUrl.searchParams.has("isEnabled");
     const ESTIMATED_DURATION = 210; // in seconds
-    const ESTIMATED_GAS = 1000000;
+    // const ESTIMATED_GAS = 1000000;
 
     const tokenInstanceRows = await Services.TokenInstanceService.listAllJoinedWithToken(ctx);
 
@@ -642,37 +642,37 @@ export function createGlacisApp() {
           standard: "CentrifugeV31",
           isEnabled: true,
         },
-        ...(nonHubTokenInstanceRowsByTokenId.get(row.token.id)?.flatMap((otherRow) => {
-          if (otherRow.token_instance.centrifugeId === row.token_instance.centrifugeId) {
-            return [];
-          }
-          const otherSpokeBlockchain = routeChainFromCentrifugeId(
-            otherRow.token_instance.centrifugeId
-          );
-          if (!otherSpokeBlockchain?.chainId || !otherSpokeBlockchain?.name) {
-            return [];
-          }
-
-          return [
-            {
-              tokenId: row.token.id,
-              tokenName: row.token.name || row.token.id,
-              fromAddress: row.token_instance.address,
-              toAddress: otherRow.token_instance.address,
-              fromChainId: spokeBlockchain.chainId!.toString() as `${number}`,
-              fromChainName: spokeBlockchain.name!,
-              toChainId: otherSpokeBlockchain.chainId.toString() as `${number}`,
-              toChainName: otherSpokeBlockchain.name,
-              minTransferSize: "0",
-              maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
-              decimals: row.token.decimals,
-              estimatedDuration: ESTIMATED_DURATION * 2,
-              estimatedGas: ESTIMATED_GAS * 2,
-              standard: "CentrifugeV31",
-              isEnabled: true,
-            },
-          ] satisfies Route[];
-        }) || []),
+        // Spoke-to-spoke (2-hop) routes commented out — hub↔spoke only for now.
+        // ...(nonHubTokenInstanceRowsByTokenId.get(row.token.id)?.flatMap((otherRow) => {
+        //   if (otherRow.token_instance.centrifugeId === row.token_instance.centrifugeId) {
+        //     return [];
+        //   }
+        //   const otherSpokeBlockchain = routeChainFromCentrifugeId(
+        //     otherRow.token_instance.centrifugeId
+        //   );
+        //   if (!otherSpokeBlockchain?.chainId || !otherSpokeBlockchain?.name) {
+        //     return [];
+        //   }
+        //   return [
+        //     {
+        //       tokenId: row.token.id,
+        //       tokenName: row.token.name || row.token.id,
+        //       fromAddress: row.token_instance.address,
+        //       toAddress: otherRow.token_instance.address,
+        //       fromChainId: spokeBlockchain.chainId!.toString() as `${number}`,
+        //       fromChainName: spokeBlockchain.name!,
+        //       toChainId: otherSpokeBlockchain.chainId.toString() as `${number}`,
+        //       toChainName: otherSpokeBlockchain.name,
+        //       minTransferSize: "0",
+        //       maxTransferSize: "340282366920938463463374607431768211455",
+        //       decimals: row.token.decimals,
+        //       estimatedDuration: ESTIMATED_DURATION * 2,
+        //       estimatedGas: ESTIMATED_GAS * 2,
+        //       standard: "CentrifugeV31",
+        //       isEnabled: true,
+        //     },
+        //   ] satisfies Route[];
+        // }) || []),
       ] satisfies Route[];
     });
 

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -52,7 +52,6 @@ type LifiToken = {
   decimals: number;
 };
 
-
 /**
  * TokenBridge `send` entrypoint per chain. Not tracked in the protocol registry, so
  * addresses are pinned here. Absent chains simply omit the executable `transactionRequest`.

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -89,7 +89,6 @@ const TOKEN_BRIDGE_ADDRESS: Record<number, `0x${string}`> = {
   8453: "0x82a6c7753380f98c093b27c53f86ef6b09c40f49",
 };
 
-
 /** Per-chain block explorer tx URL builder; null when the chain isn't mapped. */
 const EXPLORER_TX_BASE: Record<number, string> = {
   1: "https://etherscan.io/tx/",
@@ -678,7 +677,9 @@ export function createGlacisApp() {
 
     const bridgeRoutes = routes.filter((r) => TOKEN_BRIDGE_ADDRESS[Number(r.fromChainId)] != null);
     const filteredRoutes =
-      isEnabled === undefined ? bridgeRoutes : bridgeRoutes.filter((r) => r.isEnabled === isEnabled);
+      isEnabled === undefined
+        ? bridgeRoutes
+        : bridgeRoutes.filter((r) => r.isEnabled === isEnabled);
 
     const paginatedRoutes = filteredRoutes.slice(offset, offset + limit);
     const baseUrl = `${requestUrl.origin}${requestUrl.pathname}`;

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -44,22 +44,6 @@ const TOOL = "centrifuge";
 const STANDARD = "CentrifugeV31";
 const NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 
-/**
- * Native currency metadata per chain, best-effort. Defaults to 18 decimals and a
- * null symbol/name for chains not listed here — LI.FI treats fee/gas amounts as the
- * source of truth and only uses this for display.
- */
-const NATIVE_CURRENCY: Record<number, { symbol: string; name: string }> = {
-  1: { symbol: "ETH", name: "Ether" },
-  10: { symbol: "ETH", name: "Ether" },
-  8453: { symbol: "ETH", name: "Ether" },
-  42161: { symbol: "ETH", name: "Ether" },
-  56: { symbol: "BNB", name: "BNB" },
-  43114: { symbol: "AVAX", name: "Avalanche" },
-  98866: { symbol: "PLUME", name: "Plume" },
-  999: { symbol: "HYPE", name: "Hyperliquid" },
-};
-
 type LifiToken = {
   address: string;
   chainId: number;
@@ -68,17 +52,6 @@ type LifiToken = {
   decimals: number;
 };
 
-/** LI.FI token object for a chain's native gas currency (fees are paid in native). */
-function nativeToken(chainId: number): LifiToken {
-  const meta = NATIVE_CURRENCY[chainId];
-  return {
-    address: NATIVE_TOKEN_ADDRESS,
-    chainId,
-    symbol: meta?.symbol ?? null,
-    name: meta?.name ?? null,
-    decimals: 18,
-  };
-}
 
 /**
  * TokenBridge `send` entrypoint per chain. Not tracked in the protocol registry, so
@@ -189,8 +162,8 @@ const quoteParams = z.object({
       .regex(/^0x[a-fA-F0-9]{40}$/)
       .optional()
   ),
-  fromAddress: zQueryAddress,
-  toAddress: zQueryAddressOptional,
+  fromAddress: zQueryAddressOptional,
+  toAddress: zQueryAddress,
   // Transfers are 1:1, so slippage is ignored
   slippage: z.preprocess(queryParamToString, z.string().optional()),
 });
@@ -201,7 +174,7 @@ type QuoteInput = {
   fromToken: string;
   fromAmount: bigint;
   fromAddress?: string;
-  toAddress?: string;
+  toAddress: string;
 };
 
 /** Shared Airlift-style fee quote (POST /quote only per Glacis off-chain interface). */
@@ -385,10 +358,9 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
         {
           name: "Bridge fee",
           description: "Cross-chain message delivery fee, paid in the source chain native token",
-          percentage: "0",
-          token: nativeToken(fromChainId),
+          chainId: fromChainId,
+          tokenAddress: NATIVE_TOKEN_ADDRESS,
           amount: totalFee.toString(),
-          amountUSD: null,
           included: false,
         },
       ],

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -227,6 +227,8 @@ const quoteParams = z.object({
   ),
   fromAddress: zQueryAddressOptional,
   toAddress: zQueryAddressOptional,
+  // Transfers are 1:1, so slippage is ignored
+  slippage: z.preprocess(queryParamToString, z.string().optional()),
 });
 
 type QuoteInput = {
@@ -582,7 +584,7 @@ export function createGlacisApp() {
     return handleStatus(c, ctx, c.req.query("txHash") ?? "");
   });
 
-  app.get("/transactions/:txHash", async (c) => {
+  app.get("/transaction/:txHash", async (c) => {
     const ctx = apiContext(c);
     return handleStatus(c, ctx, c.req.param("txHash"));
   });
@@ -725,7 +727,7 @@ export function createGlacisApp() {
     });
   });
 
-  app.post("/quote", sValidator("query", quoteParams), async (c) => {
+  app.get("/quote", sValidator("query", quoteParams), async (c) => {
     const ctx = apiContext(c);
     const q = c.req.valid("query");
     return handleQuote(c, ctx, {

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -43,6 +43,9 @@ const TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
 const TOOL = "centrifuge";
 const STANDARD = "CentrifugeV31";
 const NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+/** uint128 max, used as the transfer size ceiling and the fromAmount zod bound. */
+const UINT128_MAX_STR: `${number}` = "340282366920938463463374607431768211455";
+const UINT128_MAX = BigInt(UINT128_MAX_STR);
 
 type LifiToken = {
   address: string;
@@ -85,7 +88,7 @@ function addressToBytes32(address: string): `0x${string}` {
 
 /** Take the low 20 bytes of a 32-byte word as an address. */
 function bytes32ToAddress(word: string): `0x${string}` {
-  return `0x${word.replace(/^0x/, "").slice(-40)}` as `0x${string}`;
+  return `0x${word.replace(/^0x/, "").slice(-40).toLowerCase()}` as `0x${string}`;
 }
 
 type Route = {
@@ -102,7 +105,7 @@ type Route = {
   decimals: number;
   estimatedDuration: number;
   estimatedGas: number;
-  standard: string;
+  standard: typeof STANDARD;
 };
 
 /** Hono query values are strings (or string[] if repeated); normalize for Zod. */
@@ -130,7 +133,7 @@ const zQueryUint128 = z.preprocess(
     .string()
     .regex(/^\d+$/)
     .transform((s) => BigInt(s))
-    .pipe(z.bigint().min(1n).max(340282366920938463463374607431768211455n))
+    .pipe(z.bigint().min(1n).max(UINT128_MAX))
 );
 
 const zQueryAddress = z.preprocess(queryParamToString, z.string().regex(/^0x[a-fA-F0-9]{40}$/));
@@ -171,6 +174,7 @@ type QuoteInput = {
   fromChainId: number;
   toChainId: number;
   fromToken: string;
+  toToken?: string;
   fromAmount: bigint;
   fromAddress?: string;
   toAddress: string;
@@ -178,7 +182,7 @@ type QuoteInput = {
 
 /** Shared Airlift-style fee quote (POST /quote only per Glacis off-chain interface). */
 async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Promise<Response> {
-  const { fromChainId, toChainId, fromAmount, fromToken, fromAddress, toAddress } = input;
+  const { fromChainId, toChainId, fromAmount, fromToken, toToken, fromAddress, toAddress } = input;
   const ESTIMATED_DURATION = 210; // in seconds
 
   const fromCentIdStr = Services.BlockchainService.getCentrifugeIdFromChainId(fromChainId);
@@ -192,11 +196,16 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
     return c.json({ error: "Origin and destination chain cannot be the same" }, 400);
   }
 
-  const tokenInstances = await Services.TokenInstanceService.query(ctx, {
-    address: fromToken as `0x${string}`,
-  });
-  const fromInstance = tokenInstances.find((ti) => ti.read().centrifugeId === String(fromCentId));
-  const toInstance = tokenInstances.find((ti) => ti.read().centrifugeId === String(toCentId));
+  const [fromInstance, toInstance] = await Promise.all([
+    Services.TokenInstanceService.get(ctx, {
+      address: fromToken as `0x${string}`,
+      centrifugeId: String(fromCentId),
+    }),
+    Services.TokenInstanceService.get(ctx, {
+      address: fromToken as `0x${string}`,
+      centrifugeId: String(toCentId),
+    }),
+  ]);
 
   if (!fromInstance) {
     return c.json({ error: "Token does not exist on the origin chain" }, 404);
@@ -212,6 +221,21 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
   }
 
   const tokenId = fromData.tokenId;
+
+  // `toToken` is accepted for LI.FI parity but must resolve to the same share class as
+  // `fromToken` on the destination chain. Transfers are 1:1, so a mismatch is rejected.
+  if (toToken !== undefined && toToken !== fromToken) {
+    const toTokenInstance = await Services.TokenInstanceService.get(ctx, {
+      address: toToken as `0x${string}`,
+      centrifugeId: String(toCentId),
+    });
+    if (!toTokenInstance) {
+      return c.json({ error: "toToken does not exist on the destination chain" }, 404);
+    }
+    if (toTokenInstance.read().tokenId !== tokenId) {
+      return c.json({ error: "toToken is not the same share class as fromToken" }, 400);
+    }
+  }
   const hubCentId = centrifugeId(tokenId);
   const isFromHub = fromCentId === hubCentId;
   const isToHub = toCentId === hubCentId;
@@ -498,7 +522,7 @@ async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promis
   });
 }
 
-/** LI.FI-style routes: `GET /routes`, `POST /quote`, `GET /status`, `GET /transactions/:txHash`. */
+/** LI.FI-style routes: `GET /routes`, `GET /quote`, `GET /status`, `GET /transaction/:txHash`. */
 export function createGlacisApp() {
   const app = new Hono<ApiEnv>();
 
@@ -519,103 +543,71 @@ export function createGlacisApp() {
     const GAS_INITIATE_TRANSFER_SHARES = 369413;
     const GAS_EXECUTE_TRANSFER_SHARES = 254235;
 
-    const tokenInstanceRows = await Services.TokenInstanceService.listAllJoinedWithToken(ctx);
+    const rows = await Services.TokenInstanceService.listAllJoinedWithToken(ctx);
 
-    const hubTokenInstanceRowsByTokenId = new Map<string, (typeof tokenInstanceRows)[number]>();
-    const nonHubTokenInstanceRowsByTokenId = new Map<string, typeof tokenInstanceRows>();
-    const nonHubTokenInstanceRows = tokenInstanceRows.filter((row) => {
-      const isSpoke =
-        Number(row.token_instance.centrifugeId) !== centrifugeId(row.token_instance.tokenId);
-      if (isSpoke) {
-        const tokenRows = nonHubTokenInstanceRowsByTokenId.get(row.token.id) || [];
-        tokenRows.push(row);
-        nonHubTokenInstanceRowsByTokenId.set(row.token.id, tokenRows);
-        return true;
+    // Partition instances: the hub instance lives on the token's hub chain (its
+    // instance centrifugeId matches the token's recorded hub centrifugeId); all
+    // others are spokes. Routes are hub<->spoke pairs per token. Tokens without a
+    // recorded hub centrifugeId are skipped (no hub chain to route through).
+    const hubByTokenId = new Map<string, (typeof rows)[number]>();
+    const spokeRows: typeof rows = [];
+    for (const row of rows) {
+      const hubCentId = row.token.centrifugeId;
+      if (hubCentId == null) continue;
+      if (row.token_instance.centrifugeId === hubCentId) {
+        hubByTokenId.set(row.token.id, row);
+      } else {
+        spokeRows.push(row);
       }
-      hubTokenInstanceRowsByTokenId.set(row.token.id, row);
-      return false;
-    });
+    }
 
-    const routes = nonHubTokenInstanceRows.flatMap((row) => {
-      const hubBlockchain = routeChainFromCentrifugeId(row.token.centrifugeId!);
-      const spokeBlockchain = routeChainFromCentrifugeId(row.token_instance.centrifugeId);
-      const hubRow = hubTokenInstanceRowsByTokenId.get(row.token.id);
+    const routes: Route[] = [];
+    for (const spokeRow of spokeRows) {
+      const hubRow = hubByTokenId.get(spokeRow.token.id);
+      if (!hubRow) continue;
 
-      if (
-        !hubBlockchain?.chainId ||
-        !hubBlockchain?.name ||
-        !spokeBlockchain?.chainId ||
-        !spokeBlockchain?.name ||
-        !hubRow
-      ) {
-        return [];
-      }
+      const hubChain = routeChainFromCentrifugeId(hubRow.token_instance.centrifugeId);
+      const spokeChain = routeChainFromCentrifugeId(spokeRow.token_instance.centrifugeId);
+      if (!hubChain || !spokeChain) continue;
 
-      return [
-        {
-          tokenId: row.token.id,
-          tokenName: row.token.name || row.token.id,
-          fromAddress: hubRow.token_instance.address,
-          toAddress: row.token_instance.address,
-          fromChainId: hubBlockchain.chainId.toString() as `${number}`,
-          fromChainName: hubBlockchain.name,
-          toChainId: spokeBlockchain.chainId.toString() as `${number}`,
-          toChainName: spokeBlockchain.name,
-          minTransferSize: "0",
-          maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
-          decimals: row.token.decimals,
-          estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: GAS_EXECUTE_TRANSFER_SHARES,
-          standard: "CentrifugeV31",
-        },
-        {
-          tokenId: row.token.id,
-          tokenName: row.token.name || row.token.id,
-          fromAddress: row.token_instance.address,
-          toAddress: hubRow.token_instance.address,
-          fromChainId: spokeBlockchain.chainId.toString() as `${number}`,
-          fromChainName: spokeBlockchain.name,
-          toChainId: hubBlockchain.chainId.toString() as `${number}`,
-          toChainName: hubBlockchain.name,
-          minTransferSize: "0",
-          maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
-          decimals: row.token.decimals,
-          estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: GAS_INITIATE_TRANSFER_SHARES,
-          standard: "CentrifugeV31",
-        },
-        // Spoke-to-spoke (2-hop) routes commented out — hub↔spoke only for now.
-        // ...(nonHubTokenInstanceRowsByTokenId.get(row.token.id)?.flatMap((otherRow) => {
-        //   if (otherRow.token_instance.centrifugeId === row.token_instance.centrifugeId) {
-        //     return [];
-        //   }
-        //   const otherSpokeBlockchain = routeChainFromCentrifugeId(
-        //     otherRow.token_instance.centrifugeId
-        //   );
-        //   if (!otherSpokeBlockchain?.chainId || !otherSpokeBlockchain?.name) {
-        //     return [];
-        //   }
-        //   return [
-        //     {
-        //       tokenId: row.token.id,
-        //       tokenName: row.token.name || row.token.id,
-        //       fromAddress: row.token_instance.address,
-        //       toAddress: otherRow.token_instance.address,
-        //       fromChainId: spokeBlockchain.chainId!.toString() as `${number}`,
-        //       fromChainName: spokeBlockchain.name!,
-        //       toChainId: otherSpokeBlockchain.chainId.toString() as `${number}`,
-        //       toChainName: otherSpokeBlockchain.name,
-        //       minTransferSize: "0",
-        //       maxTransferSize: "340282366920938463463374607431768211455",
-        //       decimals: row.token.decimals,
-        //       estimatedDuration: ESTIMATED_DURATION * 2,
-        //       estimatedGas: ESTIMATED_GAS * 2,
-        //       standard: "CentrifugeV31",
-        //     },
-        //   ] satisfies Route[];
-        // }) || []),
-      ] satisfies Route[];
-    });
+      const base: Pick<
+        Route,
+        "tokenId" | "tokenName" | "decimals" | "estimatedDuration" | "standard"
+      > = {
+        tokenId: spokeRow.token.id,
+        tokenName: spokeRow.token.name || spokeRow.token.id,
+        decimals: spokeRow.token.decimals,
+        estimatedDuration: ESTIMATED_DURATION,
+        standard: STANDARD,
+      };
+
+      // hub -> spoke (ExecuteTransferShares)
+      routes.push({
+        ...base,
+        fromAddress: hubRow.token_instance.address,
+        toAddress: spokeRow.token_instance.address,
+        fromChainId: hubChain.chainId.toString() as `${number}`,
+        fromChainName: hubChain.name,
+        toChainId: spokeChain.chainId.toString() as `${number}`,
+        toChainName: spokeChain.name,
+        minTransferSize: "0",
+        maxTransferSize: UINT128_MAX_STR,
+        estimatedGas: GAS_EXECUTE_TRANSFER_SHARES,
+      });
+      // spoke -> hub (InitiateTransferShares)
+      routes.push({
+        ...base,
+        fromAddress: spokeRow.token_instance.address,
+        toAddress: hubRow.token_instance.address,
+        fromChainId: spokeChain.chainId.toString() as `${number}`,
+        fromChainName: spokeChain.name,
+        toChainId: hubChain.chainId.toString() as `${number}`,
+        toChainName: hubChain.name,
+        minTransferSize: "0",
+        maxTransferSize: UINT128_MAX_STR,
+        estimatedGas: GAS_INITIATE_TRANSFER_SHARES,
+      });
+    }
 
     const bridgeRoutes = routes.filter((r) => TOKEN_BRIDGE_ADDRESS[Number(r.fromChainId)] != null);
 
@@ -632,6 +624,7 @@ export function createGlacisApp() {
       toChainId: q.toChain,
       fromAmount: q.fromAmount,
       fromToken: q.fromToken,
+      toToken: q.toToken,
       fromAddress: q.fromAddress,
       toAddress: q.toAddress,
     });

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -116,21 +116,6 @@ function bytes32ToAddress(word: string): `0x${string}` {
   return `0x${word.replace(/^0x/, "").slice(-40)}` as `0x${string}`;
 }
 
-const routesParams = z.object({
-  limit: z.coerce.number().int().min(0).max(1000).optional().default(100),
-  offset: z.coerce
-    .number()
-    .int()
-    .min(0)
-    .max(Number.MAX_SAFE_INTEGER - 1000)
-    .optional()
-    .default(0),
-  isEnabled: z
-    .union([z.literal("true"), z.literal("false")])
-    .optional()
-    .transform((val) => (val === undefined ? undefined : val === "true")),
-});
-
 type Route = {
   tokenId: string;
   tokenName: string;
@@ -146,7 +131,6 @@ type Route = {
   estimatedDuration: number;
   estimatedGas: number;
   standard: string;
-  isEnabled: boolean;
 };
 
 /** Hono query values are strings (or string[] if repeated); normalize for Zod. */
@@ -177,10 +161,7 @@ const zQueryUint128 = z.preprocess(
     .pipe(z.bigint().min(1n).max(340282366920938463463374607431768211455n))
 );
 
-const zQueryAddress = z.preprocess(
-  queryParamToString,
-  z.string().regex(/^0x[a-fA-F0-9]{40}$/)
-);
+const zQueryAddress = z.preprocess(queryParamToString, z.string().regex(/^0x[a-fA-F0-9]{40}$/));
 
 const zQueryAddressOptional = z.preprocess(
   queryParamToString,
@@ -246,10 +227,10 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
   const toInstance = tokenInstances.find((ti) => ti.read().centrifugeId === String(toCentId));
 
   if (!fromInstance) {
-    return c.json({ error: "Token does not exist on the origin chain" }, 400);
+    return c.json({ error: "Token does not exist on the origin chain" }, 404);
   }
   if (!toInstance) {
-    return c.json({ error: "Token does not exist on the destination chain" }, 400);
+    return c.json({ error: "Token does not exist on the destination chain" }, 404);
   }
 
   const fromData = fromInstance.read();
@@ -266,7 +247,7 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
   const hubChainId = Services.BlockchainService.getChainIdFromCentrifugeId(String(hubCentId));
 
   if (hubChainId == null) {
-    return c.json({ error: "Hub chain not found for this token" }, 400);
+    return c.json({ error: "Hub chain not found for this token" }, 500);
   }
 
   let estimatedDuration = ESTIMATED_DURATION;
@@ -352,6 +333,7 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
   // Fee is paid in native (value); refund defaults to the receiver.
   const bridgeAddress = TOKEN_BRIDGE_ADDRESS[fromChainId] ?? null;
   const receiver = toAddress ?? fromAddress ?? null;
+
   let parameters: {
     contractAddress: `0x${string}`;
     functionName: string;
@@ -384,37 +366,35 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
   const amount = fromAmount.toString(); // 1:1 transfer — toAmount equals fromAmount
 
   return c.json({
-    data: {
-      tool: TOOL,
-      standard: STANDARD,
-      fromChainId,
-      toChainId,
-      fromToken: fromTokenObj,
-      toToken: toTokenObj,
+    tool: TOOL,
+    standard: STANDARD,
+    fromChainId,
+    toChainId,
+    fromToken: fromTokenObj,
+    toToken: toTokenObj,
+    fromAmount: amount,
+    toAmount: amount,
+    estimate: {
       fromAmount: amount,
       toAmount: amount,
-      estimate: {
-        fromAmount: amount,
-        toAmount: amount,
-        // No slippage on a deterministic 1:1 transfer, so the minimum equals the amount.
-        toAmountMin: amount,
-        approvalAddress: bridgeAddress,
-        executionDuration: estimatedDuration,
-        feeCosts: [
-          {
-            name: "Bridge fee",
-            description: "Cross-chain message delivery fee, paid in the source chain native token",
-            percentage: "0",
-            token: nativeToken(fromChainId),
-            amount: totalFee.toString(),
-            amountUSD: null,
-            included: false,
-          },
-        ],
-        gasEstimate: estimatedGas,
-      },
-      parameters,
+      // No slippage on a deterministic 1:1 transfer, so the minimum equals the amount.
+      toAmountMin: amount,
+      approvalAddress: bridgeAddress,
+      executionDuration: estimatedDuration,
+      feeCosts: [
+        {
+          name: "Bridge fee",
+          description: "Cross-chain message delivery fee, paid in the source chain native token",
+          percentage: "0",
+          token: nativeToken(fromChainId),
+          amount: totalFee.toString(),
+          amountUSD: null,
+          included: false,
+        },
+      ],
+      gasEstimate: estimatedGas,
     },
+    parameters,
   });
 }
 
@@ -437,15 +417,13 @@ async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promis
   const payloadSvc = await Services.CrosschainPayloadService.getByCreatedAtTxHash(ctx, txHashNorm);
   if (!payloadSvc) {
     return c.json({
-      data: {
-        transactionId: txHashNorm,
-        tool: TOOL,
-        status: "NOT_FOUND",
-        substatus: null,
-        substatusMessage: null,
-        sending: { txHash: txHashNorm, txLink: null, chainId: null, amount: null, token: null },
-        receiving: null,
-      },
+      transactionId: txHashNorm,
+      tool: TOOL,
+      status: "NOT_FOUND",
+      substatus: null,
+      substatusMessage: null,
+      sending: { txHash: txHashNorm, txLink: null, chainId: null, amount: null, token: null },
+      receiving: null,
     });
   }
 
@@ -521,33 +499,31 @@ async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promis
   const receivingDone = Boolean(receivingTxHash);
 
   return c.json({
-    data: {
-      transactionId: payload.id,
-      tool: TOOL,
-      status,
-      substatus,
-      substatusMessage: null,
-      toAddress,
-      sending: {
-        txHash: payload.createdAtTxHash,
-        txLink: explorerTxLink(fromChainId, payload.createdAtTxHash),
-        chainId: fromChainId,
-        amount,
-        token: tokenObj ? { ...tokenObj, chainId: fromChainId ?? tokenObj.chainId } : null,
-        gasPrice: payload.gasPrice != null ? payload.gasPrice.toString() : null,
-        timestamp: toUnix(payload.createdAt),
-      },
-      receiving: receivingDone
-        ? {
-            txHash: receivingTxHash,
-            txLink: explorerTxLink(toChainId, receivingTxHash),
-            chainId: toChainId,
-            tokenAddress: tokenObj?.address ?? null,
-            tokenAmount: amount,
-            timestamp: toUnix(payload.completedAt ?? payload.deliveredAt),
-          }
-        : null,
+    transactionId: payload.id,
+    tool: TOOL,
+    status,
+    substatus,
+    substatusMessage: null,
+    toAddress,
+    sending: {
+      txHash: payload.createdAtTxHash,
+      txLink: explorerTxLink(fromChainId, payload.createdAtTxHash),
+      chainId: fromChainId,
+      amount,
+      token: tokenObj ? { ...tokenObj, chainId: fromChainId ?? tokenObj.chainId } : null,
+      gasPrice: payload.gasPrice != null ? payload.gasPrice.toString() : null,
+      timestamp: toUnix(payload.createdAt),
     },
+    receiving: receivingDone
+      ? {
+          txHash: receivingTxHash,
+          txLink: explorerTxLink(toChainId, receivingTxHash),
+          chainId: toChainId,
+          tokenAddress: tokenObj?.address ?? null,
+          tokenAmount: amount,
+          timestamp: toUnix(payload.completedAt ?? payload.deliveredAt),
+        }
+      : null,
   });
 }
 
@@ -566,13 +542,10 @@ export function createGlacisApp() {
     return handleStatus(c, ctx, c.req.param("txHash"));
   });
 
-  app.get("/routes", sValidator("query", routesParams), async (c) => {
+  app.get("/routes", async (c) => {
     const ctx = apiContext(c);
-    const { limit, offset, isEnabled } = c.req.valid("query");
-    const requestUrl = new URL(c.req.url);
-    const pagingIncludesIsEnabled = requestUrl.searchParams.has("isEnabled");
     const ESTIMATED_DURATION = 210; // in seconds
-    // const ESTIMATED_GAS = 1000000;
+    const ESTIMATED_GAS = 1000000;
 
     const tokenInstanceRows = await Services.TokenInstanceService.listAllJoinedWithToken(ctx);
 
@@ -620,9 +593,8 @@ export function createGlacisApp() {
           maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
           decimals: row.token.decimals,
           estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: 1000000,
+          estimatedGas: ESTIMATED_GAS,
           standard: "CentrifugeV31",
-          isEnabled: true,
         },
         {
           tokenId: row.token.id,
@@ -637,9 +609,8 @@ export function createGlacisApp() {
           maxTransferSize: "340282366920938463463374607431768211455", // uint128 max
           decimals: row.token.decimals,
           estimatedDuration: ESTIMATED_DURATION,
-          estimatedGas: 1000000,
+          estimatedGas: ESTIMATED_GAS,
           standard: "CentrifugeV31",
-          isEnabled: true,
         },
         // Spoke-to-spoke (2-hop) routes commented out — hub↔spoke only for now.
         // ...(nonHubTokenInstanceRowsByTokenId.get(row.token.id)?.flatMap((otherRow) => {
@@ -668,7 +639,6 @@ export function createGlacisApp() {
         //       estimatedDuration: ESTIMATED_DURATION * 2,
         //       estimatedGas: ESTIMATED_GAS * 2,
         //       standard: "CentrifugeV31",
-        //       isEnabled: true,
         //     },
         //   ] satisfies Route[];
         // }) || []),
@@ -676,34 +646,9 @@ export function createGlacisApp() {
     });
 
     const bridgeRoutes = routes.filter((r) => TOKEN_BRIDGE_ADDRESS[Number(r.fromChainId)] != null);
-    const filteredRoutes =
-      isEnabled === undefined
-        ? bridgeRoutes
-        : bridgeRoutes.filter((r) => r.isEnabled === isEnabled);
-
-    const paginatedRoutes = filteredRoutes.slice(offset, offset + limit);
-    const baseUrl = `${requestUrl.origin}${requestUrl.pathname}`;
-
-    const routesPagingQuery = (off: number): string => {
-      const p = new URLSearchParams();
-      p.set("limit", String(limit));
-      p.set("offset", String(off));
-      if (pagingIncludesIsEnabled && isEnabled !== undefined) {
-        p.set("isEnabled", isEnabled ? "true" : "false");
-      }
-      return p.toString();
-    };
 
     return c.json({
-      paging: {
-        self: `${baseUrl}?${routesPagingQuery(offset)}`,
-        prev: offset - limit >= 0 ? `${baseUrl}?${routesPagingQuery(offset - limit)}` : null,
-        next:
-          offset + limit < filteredRoutes.length
-            ? `${baseUrl}?${routesPagingQuery(offset + limit)}`
-            : null,
-      },
-      data: paginatedRoutes,
+      routes: bridgeRoutes,
     });
   });
 

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -1,5 +1,6 @@
 import { sValidator } from "@hono/standard-validator";
 import { type Context, Hono } from "hono";
+import { encodeFunctionData } from "viem";
 import * as z from "zod";
 import { getContractAddressForChain, REGISTRY_VERSION_ORDER } from "../contracts";
 import { emptyMessage, MessageType } from "../helpers/messaging";
@@ -36,8 +37,101 @@ function routeChainFromCentrifugeId(
   return { chainId, name: Services.BlockchainService.networkNameFromChainId(chainId) };
 }
 
-/** Glacis Airlift-style tx hash; invalid input returns 400 before lookup. */
+/** LI.FI-style tx hash; invalid input returns 400 before lookup. */
 const TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
+
+/** Tool identifier reported to LI.FI for every route/quote/status. */
+const TOOL = "centrifuge";
+const STANDARD = "CentrifugeV31";
+const NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+
+/**
+ * Native currency metadata per chain, best-effort. Defaults to 18 decimals and a
+ * null symbol/name for chains not listed here — LI.FI treats fee/gas amounts as the
+ * source of truth and only uses this for display.
+ */
+const NATIVE_CURRENCY: Record<number, { symbol: string; name: string }> = {
+  1: { symbol: "ETH", name: "Ether" },
+  10: { symbol: "ETH", name: "Ether" },
+  8453: { symbol: "ETH", name: "Ether" },
+  42161: { symbol: "ETH", name: "Ether" },
+  56: { symbol: "BNB", name: "BNB" },
+  43114: { symbol: "AVAX", name: "Avalanche" },
+  98866: { symbol: "PLUME", name: "Plume" },
+  999: { symbol: "HYPE", name: "Hyperliquid" },
+};
+
+type LifiToken = {
+  address: string;
+  chainId: number;
+  symbol: string | null;
+  name: string | null;
+  decimals: number;
+};
+
+/** LI.FI token object for a chain's native gas currency (fees are paid in native). */
+function nativeToken(chainId: number): LifiToken {
+  const meta = NATIVE_CURRENCY[chainId];
+  return {
+    address: NATIVE_TOKEN_ADDRESS,
+    chainId,
+    symbol: meta?.symbol ?? null,
+    name: meta?.name ?? null,
+    decimals: 18,
+  };
+}
+
+/**
+ * TokenBridge `send` entrypoint per chain. Not tracked in the protocol registry, so
+ * addresses are pinned here. Absent chains simply omit the executable `transactionRequest`.
+ */
+const TOKEN_BRIDGE_ADDRESS: Record<number, `0x${string}`> = {
+  1: "0x82a6c7753380f98c093b27c53f86ef6b09c40f49",
+  8453: "0x82a6c7753380f98c093b27c53f86ef6b09c40f49",
+};
+
+const TOKEN_BRIDGE_SEND_ABI = [
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "payable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "receiver", type: "bytes32" },
+      { name: "destinationChainId", type: "uint256" },
+      { name: "refundAddress", type: "address" },
+    ],
+    outputs: [{ type: "bytes" }],
+  },
+] as const;
+
+/** Per-chain block explorer tx URL builder; null when the chain isn't mapped. */
+const EXPLORER_TX_BASE: Record<number, string> = {
+  1: "https://etherscan.io/tx/",
+  10: "https://optimistic.etherscan.io/tx/",
+  56: "https://bscscan.com/tx/",
+  8453: "https://basescan.org/tx/",
+  42161: "https://arbiscan.io/tx/",
+  43114: "https://snowtrace.io/tx/",
+};
+
+/** Block explorer tx URL for a chain, falling back to centrifugescan; null without inputs. */
+function explorerTxLink(chainId: number | null, txHash: string | null): string | null {
+  if (chainId == null || !txHash) return null;
+  const base = EXPLORER_TX_BASE[chainId];
+  return base ? `${base}${txHash}` : `https://centrifugescan.io/tx/${txHash}`;
+}
+
+/** Left-pad a 20-byte address to a 32-byte word for the bridge `receiver` arg. */
+function addressToBytes32(address: string): `0x${string}` {
+  return `0x${address.replace(/^0x/, "").toLowerCase().padStart(64, "0")}` as `0x${string}`;
+}
+
+/** Take the low 20 bytes of a 32-byte word as an address. */
+function bytes32ToAddress(word: string): `0x${string}` {
+  return `0x${word.replace(/^0x/, "").slice(-40)}` as `0x${string}`;
+}
 
 const routesParams = z.object({
   limit: z.coerce.number().int().min(0).max(1000).optional().default(100),
@@ -105,12 +199,34 @@ const zQueryTokenAddress = z.preprocess(
   z.string().regex(/^0x[a-fA-F0-9]{40}$/)
 );
 
-/** Airlift spec: POST /quote with `fromChain`, `toChain`, `fromToken`, `fromAmount` as query params. */
+const zQueryAddressOptional = z.preprocess(
+  queryParamToString,
+  z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{40}$/)
+    .optional()
+);
+
+/**
+ * POST /quote with `fromChain`, `toChain`, `fromToken`, `fromAmount` as query params.
+ * `toToken` is accepted for LI.FI parity but must resolve to the same share class as
+ * `fromToken` (transfers are 1:1). `fromAddress`/`toAddress` are optional and only used
+ * to build the executable `transactionRequest`.
+ */
 const quoteParams = z.object({
   fromChain: zQueryChainId,
   toChain: zQueryChainId,
   fromAmount: zQueryUint128,
   fromToken: zQueryTokenAddress,
+  toToken: z.preprocess(
+    queryParamToString,
+    z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/)
+      .optional()
+  ),
+  fromAddress: zQueryAddressOptional,
+  toAddress: zQueryAddressOptional,
 });
 
 type QuoteInput = {
@@ -118,11 +234,13 @@ type QuoteInput = {
   toChainId: number;
   fromToken: string;
   fromAmount: bigint;
+  fromAddress?: string;
+  toAddress?: string;
 };
 
 /** Shared Airlift-style fee quote (POST /quote only per Glacis off-chain interface). */
 async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Promise<Response> {
-  const { fromChainId, toChainId, fromAmount, fromToken } = input;
+  const { fromChainId, toChainId, fromAmount, fromToken, fromAddress, toAddress } = input;
   const ESTIMATED_DURATION = 210; // in seconds
 
   const fromCentIdStr = Services.BlockchainService.getCentrifugeIdFromChainId(fromChainId);
@@ -226,96 +344,247 @@ async function handleQuote(c: Context, ctx: ApiContext, input: QuoteInput): Prom
     totalFee = initiateFee + executeFee;
   }
 
+  // Share class metadata (symbol/name) lives on the Token; decimals are on the instance.
+  const [token] = await Services.TokenService.query(ctx, { id: tokenId });
+  const tokenMeta = token?.read();
+
+  const fromTokenObj: LifiToken = {
+    address: fromData.address,
+    chainId: fromChainId,
+    symbol: tokenMeta?.symbol ?? null,
+    name: tokenMeta?.name ?? null,
+    decimals: fromData.decimals,
+  };
+  const toTokenObj: LifiToken = {
+    address: toData.address,
+    chainId: toChainId,
+    symbol: tokenMeta?.symbol ?? null,
+    name: tokenMeta?.name ?? null,
+    decimals: toData.decimals,
+  };
+
+  // Executable source-chain call, when the TokenBridge is deployed on the origin and we
+  // know the receiver. Fee is paid in native (value); refund defaults to the receiver.
+  const bridgeAddress = TOKEN_BRIDGE_ADDRESS[fromChainId] ?? null;
+  const receiver = toAddress ?? fromAddress ?? null;
+  let transactionRequest: {
+    to: `0x${string}`;
+    data: `0x${string}`;
+    value: string;
+    chainId: number;
+  } | null = null;
+  if (bridgeAddress && receiver) {
+    transactionRequest = {
+      to: bridgeAddress,
+      data: encodeFunctionData({
+        abi: TOKEN_BRIDGE_SEND_ABI,
+        functionName: "send",
+        args: [
+          fromToken as `0x${string}`,
+          fromAmount,
+          addressToBytes32(receiver),
+          BigInt(toChainId),
+          (fromAddress ?? receiver) as `0x${string}`,
+        ],
+      }),
+      value: totalFee.toString(),
+      chainId: fromChainId,
+    };
+  }
+
+  const amount = fromAmount.toString(); // 1:1 transfer — toAmount equals fromAmount
+
   return c.json({
     data: {
-      // Same as fromAmount while tokenFee is 0 (native-only bridge fees are in feeCosts).
-      toAmount: fromAmount.toString(),
-      estimatedDuration,
-      estimatedGas,
-      feeCosts: {
-        bridgeFee: {
-          tokenFee: "0",
-          nativeFee: totalFee.toString(),
-        },
-        airliftFee: {
-          tokenFee: "0",
-          nativeFee: "0",
-        },
+      tool: TOOL,
+      standard: STANDARD,
+      fromChainId,
+      toChainId,
+      fromToken: fromTokenObj,
+      toToken: toTokenObj,
+      fromAmount: amount,
+      toAmount: amount,
+      estimate: {
+        fromAmount: amount,
+        toAmount: amount,
+        // No slippage on a deterministic 1:1 transfer, so the minimum equals the amount.
+        toAmountMin: amount,
+        approvalAddress: bridgeAddress,
+        executionDuration: estimatedDuration,
+        feeCosts: [
+          {
+            name: "Bridge fee",
+            description: "Cross-chain message delivery fee, paid in the source chain native token",
+            percentage: "0",
+            token: nativeToken(fromChainId),
+            amount: totalFee.toString(),
+            amountUSD: null,
+            included: false,
+          },
+        ],
+        gasCosts: [
+          {
+            type: "SEND",
+            price: null,
+            estimate: estimatedGas.toString(),
+            limit: estimatedGas.toString(),
+            amount: null,
+            amountUSD: null,
+            token: nativeToken(fromChainId),
+          },
+        ],
       },
+      transactionRequest,
     },
   });
 }
 
-/** Glacis / Airlift-style routes: `GET /transactions/:txHash`, `GET /routes`, `POST /quote`. */
+/** Unix seconds from a DB timestamp (Date), or null. */
+function toUnix(value: unknown): number | null {
+  if (value instanceof Date) return Math.floor(value.getTime() / 1000);
+  return null;
+}
+
+/**
+ * LI.FI-style transfer status for a source-chain tx hash. Returns HTTP 200 with a
+ * `NOT_FOUND`/`PENDING`/`DONE` status even before the payload is indexed, since LI.FI polls it.
+ */
+async function handleStatus(c: Context, ctx: ApiContext, txHash: string): Promise<Response> {
+  if (!TX_HASH_PATTERN.test(txHash)) {
+    return c.json({ error: "Bad Request" }, 400);
+  }
+  const txHashNorm = txHash as `0x${string}`;
+
+  const payloadSvc = await Services.CrosschainPayloadService.getByCreatedAtTxHash(ctx, txHashNorm);
+  if (!payloadSvc) {
+    return c.json({
+      data: {
+        transactionId: txHashNorm,
+        tool: TOOL,
+        status: "NOT_FOUND",
+        substatus: "NOT_FOUND",
+        substatusMessage: null,
+        sending: { txHash: txHashNorm, txLink: null, chainId: null, amount: null, token: null },
+        receiving: null,
+      },
+    });
+  }
+
+  const payload = payloadSvc.read();
+
+  let status: string;
+  let substatus: string;
+  // CrosschainPayload has no hard FAILED state (Underpaid | InTransit | Delivered |
+  // PartiallyFailed | Completed), so FAILED is not surfaced yet.
+  switch (payload.status) {
+    case "Underpaid":
+    case "InTransit":
+      status = "PENDING";
+      substatus = payload.deliveredAt
+        ? "WAIT_DESTINATION_TRANSACTION"
+        : "WAIT_SOURCE_CONFIRMATIONS";
+      break;
+    case "Delivered":
+      status = "PENDING";
+      substatus = "WAIT_DESTINATION_TRANSACTION";
+      break;
+    case "Completed":
+      status = "DONE";
+      substatus = "COMPLETED";
+      break;
+    case "PartiallyFailed":
+      status = "DONE";
+      substatus = "PARTIAL";
+      break;
+    default:
+      status = "PENDING";
+      substatus = "UNKNOWN_ERROR";
+  }
+
+  const fromChainId = Services.BlockchainService.getChainIdFromCentrifugeId(
+    payload.fromCentrifugeId
+  );
+  const toChainId = Services.BlockchainService.getChainIdFromCentrifugeId(payload.toCentrifugeId);
+
+  // Transfer amount and receiver live on the transfer message's decoded `data`.
+  const messages = await Services.CrosschainMessageService.query(ctx, {
+    payloadId: payload.id,
+    payloadIndex: payload.index,
+  });
+  const transferMsg = messages
+    .map((m) => m.read())
+    .find(
+      (m) => m.messageType === "InitiateTransferShares" || m.messageType === "ExecuteTransferShares"
+    );
+  const msgData = transferMsg?.data as
+    | { amount?: string | number | bigint; receiver?: string }
+    | null
+    | undefined;
+  const amount = msgData?.amount != null ? String(msgData.amount) : null;
+  const toAddress = msgData?.receiver ? bytes32ToAddress(msgData.receiver) : null;
+
+  let tokenObj: LifiToken | null = null;
+  if (payload.tokenId) {
+    const [token] = await Services.TokenService.query(ctx, { id: payload.tokenId });
+    const meta = token?.read();
+    if (meta) {
+      tokenObj = {
+        address: payload.tokenId,
+        chainId: fromChainId ?? 0,
+        symbol: meta.symbol ?? null,
+        name: meta.name ?? null,
+        decimals: meta.decimals,
+      };
+    }
+  }
+
+  const receivingTxHash = payload.completedAtTxHash ?? payload.deliveredAtTxHash ?? null;
+  const receivingDone = Boolean(receivingTxHash);
+
+  return c.json({
+    data: {
+      transactionId: payload.id,
+      tool: TOOL,
+      status,
+      substatus,
+      substatusMessage: null,
+      toAddress,
+      sending: {
+        txHash: payload.createdAtTxHash,
+        txLink: explorerTxLink(fromChainId, payload.createdAtTxHash),
+        chainId: fromChainId,
+        amount,
+        token: tokenObj ? { ...tokenObj, chainId: fromChainId ?? tokenObj.chainId } : null,
+        gasPrice: payload.gasPrice != null ? payload.gasPrice.toString() : null,
+        timestamp: toUnix(payload.createdAt),
+      },
+      receiving: receivingDone
+        ? {
+            txHash: receivingTxHash,
+            txLink: explorerTxLink(toChainId, receivingTxHash),
+            chainId: toChainId,
+            amount,
+            token: tokenObj ? { ...tokenObj, chainId: toChainId ?? tokenObj.chainId } : null,
+            timestamp: toUnix(payload.completedAt ?? payload.deliveredAt),
+          }
+        : null,
+    },
+  });
+}
+
+/** LI.FI-style routes: `GET /routes`, `POST /quote`, `GET /status`, `GET /transactions/:txHash`. */
 export function createGlacisApp() {
   const app = new Hono<ApiEnv>();
 
+  // LI.FI polls status by source tx hash; keep the legacy path-param route as an alias.
+  app.get("/status", async (c) => {
+    const ctx = apiContext(c);
+    return handleStatus(c, ctx, c.req.query("txHash") ?? "");
+  });
+
   app.get("/transactions/:txHash", async (c) => {
     const ctx = apiContext(c);
-    const txHash = c.req.param("txHash");
-    if (!TX_HASH_PATTERN.test(txHash)) {
-      return c.json({ error: "Bad Request" }, 400);
-    }
-    const txHashNorm = txHash as `0x${string}`;
-
-    const payloadSvc = await Services.CrosschainPayloadService.getByCreatedAtTxHash(
-      ctx,
-      txHashNorm
-    );
-    if (!payloadSvc) {
-      return c.json({
-        data: {
-          status: "NOT_FOUND",
-          substatus: "NOT_FOUND",
-          sourceTx: txHashNorm,
-          destinationTx: null,
-          explorerLink: null,
-        },
-      });
-    }
-
-    const payload = payloadSvc.read();
-    const explorerLink = `https://centrifugescan.io/tx/${payload.createdAtTxHash}`;
-
-    let status: string;
-    let substatus: string;
-
-    // Airlift spec includes FAILED + substatuses; CrosschainPayload only has
-    // Underpaid | InTransit | Delivered | PartiallyFailed | Completed — no FAILED until domain extends.
-    switch (payload.status) {
-      case "Underpaid":
-      case "InTransit":
-        status = "PENDING";
-        substatus = payload.deliveredAt
-          ? "WAIT_DESTINATION_TRANSACTION"
-          : "WAIT_SOURCE_CONFIRMATIONS";
-        break;
-      case "Delivered":
-        status = "PENDING";
-        substatus = "WAIT_DESTINATION_TRANSACTION";
-        break;
-      case "Completed":
-        status = "DONE";
-        substatus = "COMPLETED";
-        break;
-      case "PartiallyFailed":
-        status = "DONE";
-        substatus = "PARTIAL";
-        break;
-      default:
-        status = "PENDING";
-        substatus = "UNKNOWN_ERROR";
-    }
-
-    return c.json({
-      data: {
-        status,
-        substatus,
-        sourceTx: payload.createdAtTxHash,
-        destinationTx: payload.deliveredAtTxHash || null,
-        explorerLink,
-      },
-    });
+    return handleStatus(c, ctx, c.req.param("txHash"));
   });
 
   app.get("/routes", sValidator("query", routesParams), async (c) => {
@@ -464,6 +733,8 @@ export function createGlacisApp() {
       toChainId: q.toChain,
       fromAmount: q.fromAmount,
       fromToken: q.fromToken,
+      fromAddress: q.fromAddress,
+      toAddress: q.toAddress,
     });
   });
 

--- a/src/api/glacis.ts
+++ b/src/api/glacis.ts
@@ -177,7 +177,7 @@ const zQueryUint128 = z.preprocess(
     .pipe(z.bigint().min(1n).max(340282366920938463463374607431768211455n))
 );
 
-const zQueryTokenAddress = z.preprocess(
+const zQueryAddress = z.preprocess(
   queryParamToString,
   z.string().regex(/^0x[a-fA-F0-9]{40}$/)
 );
@@ -200,7 +200,7 @@ const quoteParams = z.object({
   fromChain: zQueryChainId,
   toChain: zQueryChainId,
   fromAmount: zQueryUint128,
-  fromToken: zQueryTokenAddress,
+  fromToken: zQueryAddress,
   toToken: z.preprocess(
     queryParamToString,
     z
@@ -208,7 +208,7 @@ const quoteParams = z.object({
       .regex(/^0x[a-fA-F0-9]{40}$/)
       .optional()
   ),
-  fromAddress: zQueryAddressOptional,
+  fromAddress: zQueryAddress,
   toAddress: zQueryAddressOptional,
   // Transfers are 1:1, so slippage is ignored
   slippage: z.preprocess(queryParamToString, z.string().optional()),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,10 +22,8 @@ app.use("/tokens", apiDbMiddleware);
 app.use("/tokens/*", apiDbMiddleware);
 app.route("/tokens", createTokensApp());
 
-app.use("/transactions", apiDbMiddleware);
-app.use("/transactions/*", apiDbMiddleware);
-app.use("/routes", apiDbMiddleware);
-app.use("/quote", apiDbMiddleware);
-app.route("/", createGlacisApp());
+app.use("/bridge", apiDbMiddleware);
+app.use("/bridge/*", apiDbMiddleware);
+app.route("/bridge", createGlacisApp());
 
 export default app;


### PR DESCRIPTION
## What

Reshapes the offchain interface (`glacis.ts`) to mirror LI.FI's bridge integration spec, so LI.FI's adapter maps onto our responses without custom logic. Follows the "mirror an already-integrated bridge" requirement from their integration form.

## Changes

### `POST /quote` — LI.FI `estimate` shape
- Accepts optional `toToken`, `fromAddress`, `toAddress` (LI.FI parity).
- Returns `fromToken`/`toToken` metadata objects and an `estimate` object: `fromAmount`, `toAmount`, `toAmountMin`, `approvalAddress`, `executionDuration`, `feeCosts[]`, `gasCosts[]`.
- `feeCosts[]`: bridge fee as a native-token cost, `included: false`.
- `gasCosts[]`: single `SEND` entry from the onchain gas estimate.
- `transactionRequest`: encodes `TokenBridge.send(token, amount, receiver, destinationChainId, refundAddress)` with `value = totalFee`. Emitted only when the TokenBridge is deployed on the source chain (Ethereum + Base) and a receiver is known. `approvalAddress` = the bridge.

### Status — LI.FI `sending`/`receiving` shape
- Adds `GET /status?txHash=` (LI.FI polls by source tx hash); keeps `GET /transactions/:txHash` as an alias, both via a shared handler.
- `sending`/`receiving` objects: `txHash`, `txLink` (per-chain explorer), `chainId`, `amount`, `token`, `timestamp`, `gasPrice`.
- `amount` and receiver (`toAddress`) decoded from the `InitiateTransferShares`/`ExecuteTransferShares` message `data`.
- Adds `transactionId`, `tool`, `substatusMessage`.

### `GET /routes`
- Unchanged; already compatible.

## Deliberately deferred
- **USD values** — `amountUSD` is `null` (no native-token USD oracle in the indexer).
- **`fromAddress` in status** — not in the decoded message payload (only `receiver`); would need a source-tx lookup.
- **FAILED status** — `CrosschainPayload` has no hard-fail state, so it isn't surfaced yet.
- **`TokenBridge` address** — hardcoded (Ethereum + Base) since it's not tracked in the registry.
- **Docs** — the `routes-and-quote` docs page describes the old quote shape and will need updating when this ships.

## Testing
- `pnpm typecheck`, `eslint`, `prettier` all clean.
- `send` calldata encoding verified to round-trip (selector `0x98242b3f`).
- No automated endpoint tests added (none exist for this module yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)