### PR TITLE
fix: create new payload index for identical resends

### DIFF
--- a/src/handlers/gatewayHandlers.ts
+++ b/src/handlers/gatewayHandlers.ts
@@ -297,7 +297,7 @@ multiMapper("gateway:RepayBatch", async ({ event, context }) => {
         context,
         payloadId,
         "RepayBatch",
-        { deferAllowed: false, messageIds: batchMessageIds }
+        { deferAllowed: false, messageIds: batchMessageIds, currentTxHash: event.transaction.hash }
       );
       if (key.action !== "mutate") {
         serviceError(`RepayBatch: no open payload row for ${payloadId}`);

--- a/src/handlers/multiAdapterHandlers.ts
+++ b/src/handlers/multiAdapterHandlers.ts
@@ -52,7 +52,7 @@ multiMapper("multiAdapter:SendPayload", async ({ event, context }) => {
         context,
         payloadId,
         "SendPayload",
-        { deferAllowed: false, messageIds }
+        { deferAllowed: false, messageIds, currentTxHash: event.transaction.hash }
       );
       if (key.action === "defer") {
         serviceError(`SendPayload: cannot resolve payload key for ${payloadId}`);

--- a/src/services/CrosschainPayloadService.ts
+++ b/src/services/CrosschainPayloadService.ts
@@ -127,6 +127,7 @@ export type PayloadRowForIndex = {
   index: number;
   completedAt?: Date | null;
   sentAt?: Date | null;
+  sentAtTxHash?: `0x${string}` | null;
   underpaidAt?: Date | null;
   deliveredAt?: Date | null;
   partiallyFailedAt?: Date | null;
@@ -252,7 +253,7 @@ export function payloadIndexFromMessages(messages: MessageRowForPayloadIndex[]):
  * Resolves payload `(id, index)` for a sender-side or handle event.
  * @param eventKind - Event being processed
  * @param rows - All committed payload rows for the id
- * @param options - Defer flag, optional message linkage hint, and new-send flag
+ * @param options - Defer flag, optional message linkage hint, new-send flag, and current tx hash
  * @returns Mutate existing index, create new index, or defer (cross-chain)
  */
 export function resolvePayloadKeyForEvent(
@@ -262,10 +263,27 @@ export function resolvePayloadKeyForEvent(
     deferAllowed: boolean;
     messagePayloadIndex?: number | null;
     hasUnlinkedAwaitingMessage?: boolean;
+    /** Tx hash of the event being resolved; matches rows sent in the same tx. */
+    currentTxHash?: `0x${string}` | null;
   }
 ): ResolvePayloadKeyResult {
   const open = pickOpenPayloadRowAmong(rows);
   const newSend = options.hasUnlinkedAwaitingMessage === true;
+  const currentTxHash = options.currentTxHash ?? null;
+
+  // Same-tx rule: a row whose sentAtTxHash equals the current tx hash was sent
+  // by this very transaction - subsequent SendPayload events in the tx are
+  // adapter proof rounds for that send, and RepayBatch fires after `_send` in
+  // the same repay tx. This identity beats the min-based message hint, which
+  // can point at an older open row of another send instance.
+  if (
+    !newSend &&
+    currentTxHash != null &&
+    (eventKind === "SendPayload" || eventKind === "RepayBatch")
+  ) {
+    const sameTx = rows.find((r) => r.sentAtTxHash != null && r.sentAtTxHash === currentTxHash);
+    if (sameTx) return { action: "mutate", index: sameTx.index };
+  }
 
   // A genuine new send carries a freshly prepared, unlinked awaiting message.
   // The `messagePayloadIndex` hint is derived from prior (now terminal) linked
@@ -275,11 +293,20 @@ export function resolvePayloadKeyForEvent(
     const linked = rows.find((r) => r.index === options.messagePayloadIndex);
     if (linked) {
       const senderEvent = eventKind === "UnderpaidBatch" || eventKind === "SendPayload";
+      const sendTargetEvent = senderEvent || eventKind === "RepayBatch";
+      // With multiple rows per payload id the hint resolves to the LOWEST
+      // linked index, which may belong to a prior send that is still open
+      // (InTransit / PartiallyFailed). A send-targeting event must not follow
+      // the hint onto an already-sent row while an open unsent row (another
+      // instance awaiting its repay-send) exists - the per-event logic below
+      // routes it to that unsent row instead.
+      const staleSentHint =
+        sendTargetEvent && isPayloadSent(linked) && pickLowestOpenUnsentRowAmong(rows) != null;
       // A closed hinted row is only reused as a replay fallback when no open
       // row exists. With multiple rows per payload id the hint resolves to the
       // LOWEST linked index, which may be a prior completed send - the event
       // must then route to the open row via the per-event logic below.
-      if (isPayloadRowOpen(linked) || (senderEvent && !open)) {
+      if (!staleSentHint && (isPayloadRowOpen(linked) || (senderEvent && !open))) {
         return { action: "mutate", index: linked.index };
       }
     }
@@ -297,9 +324,17 @@ export function resolvePayloadKeyForEvent(
       if (newSend) return { action: "create", index: nextPayloadIndex(rows) };
       return { action: "defer" };
 
-    case "RepayBatch":
+    case "RepayBatch": {
+      // A repay targets an underpaid instance, which is by definition unsent
+      // (Gateway.repay requires underpaid counter > 0). Prefer the open unsent
+      // row over an older open in-transit row; the plain open fallback covers
+      // the same-tx repay ordering where SendPayload already stamped the row
+      // (then caught by the same-tx rule above) and replayed events.
+      const openUnsent = pickLowestOpenUnsentRowAmong(rows);
+      if (openUnsent) return { action: "mutate", index: openUnsent.index };
       if (open) return { action: "mutate", index: open.index };
       return { action: "defer" };
+    }
 
     case "SendPayload": {
       // Genuine new send (paid path, unlinked message from this tx's
@@ -410,7 +445,7 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
    * @param context - Ponder context
    * @param payloadId - Payload id
    * @param eventKind - Sender/handle event kind
-   * @param options - Defer flag and optional batch message ids for linkage
+   * @param options - Defer flag, optional batch message ids for linkage, and current tx hash
    * @returns Mutate, create, or defer
    */
   static async resolvePayloadKey(
@@ -420,6 +455,7 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
     options: {
       deferAllowed: boolean;
       messageIds?: readonly `0x${string}`[];
+      currentTxHash?: `0x${string}` | null;
     }
   ): Promise<ResolvePayloadKeyResult> {
     const rows = await CrosschainPayloadService.loadAllForPayloadId(context, payloadId);
@@ -444,6 +480,7 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
         eventKind,
         messagePayloadIndex,
         unlinkedAwaiting,
+        currentTxHash: options.currentTxHash ?? null,
         rowCount: rowData.length,
       })
     );
@@ -452,6 +489,7 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
       deferAllowed: options.deferAllowed,
       messagePayloadIndex,
       hasUnlinkedAwaitingMessage: unlinkedAwaiting,
+      currentTxHash: options.currentTxHash ?? null,
     });
   }
 

--- a/src/services/CrosschainPayloadService.ts
+++ b/src/services/CrosschainPayloadService.ts
@@ -136,7 +136,22 @@ export type PayloadRowForIndex = {
 type MessageRowForPayloadIndex = {
   payloadIndex?: number | null;
   payloadId?: `0x${string}` | null;
+  status?: string | null;
+  preparedAt?: Date | null;
 };
+
+/**
+ * Whether any message row is a freshly prepared, unlinked awaiting message.
+ * Such a row signals a genuine new send attempt (a brand-new `PrepareMessage`
+ * created it), as opposed to a late duplicate of an already-linked batch.
+ * @param messages - Message rows loaded for the batch's message ids
+ * @returns True when an unlinked `AwaitingBatchDelivery` row exists
+ */
+export function hasUnlinkedAwaitingMessage(messages: MessageRowForPayloadIndex[]): boolean {
+  return messages.some(
+    (m) => m.status === "AwaitingBatchDelivery" && m.payloadId == null && m.preparedAt != null
+  );
+}
 
 /** Sender / receive payload events that allocate or target `(payloadId, index)`. */
 export type PayloadEventKind = "UnderpaidBatch" | "RepayBatch" | "SendPayload" | "HandlePayload";
@@ -195,21 +210,25 @@ function pickLowestUnsentRowAmong(rows: PayloadRowForIndex[]): PayloadRowForInde
 }
 
 /**
- * Highest-index payload row for a `payloadId`.
- * @param rows - All rows for one payload id
- * @returns Row with maximum `index`
+ * Lowest-index open AND unsent payload row for a `payloadId`, or null.
+ * Excludes closed-but-unsent rows (corrupt/replayed state) so a send never
+ * mutates a completed row that was skipped over.
+ * @param rows - All rows for one payload id (any order)
+ * @returns Open unsent row with minimum `index`, or null
  */
-function highestPayloadRowAmong(rows: PayloadRowForIndex[]): PayloadRowForIndex | null {
-  if (rows.length === 0) return null;
-  return rows.reduce((max, r) => (r.index > max.index ? r : max));
+function pickLowestOpenUnsentRowAmong(rows: PayloadRowForIndex[]): PayloadRowForIndex | null {
+  const candidates = rows
+    .filter((r) => isPayloadRowOpen(r) && !isPayloadSent(r))
+    .sort((a, b) => a.index - b.index);
+  return candidates[0] ?? null;
 }
 
 /**
- * Next index when starting a new send attempt (all prior rows closed).
+ * Next index when starting a new send attempt.
  * @param rows - All rows for one payload id
  * @returns `0` when empty, else `MAX(index) + 1`
  */
-function nextPayloadIndexWhenAllClosed(rows: PayloadRowForIndex[]): number {
+function nextPayloadIndex(rows: PayloadRowForIndex[]): number {
   if (rows.length === 0) return 0;
   return Math.max(...rows.map((r) => r.index)) + 1;
 }
@@ -233,21 +252,34 @@ export function payloadIndexFromMessages(messages: MessageRowForPayloadIndex[]):
  * Resolves payload `(id, index)` for a sender-side or handle event.
  * @param eventKind - Event being processed
  * @param rows - All committed payload rows for the id
- * @param options - Defer flag and optional message linkage hint
+ * @param options - Defer flag, optional message linkage hint, and new-send flag
  * @returns Mutate existing index, create new index, or defer (cross-chain)
  */
 export function resolvePayloadKeyForEvent(
   eventKind: PayloadEventKind,
   rows: PayloadRowForIndex[],
-  options: { deferAllowed: boolean; messagePayloadIndex?: number | null }
+  options: {
+    deferAllowed: boolean;
+    messagePayloadIndex?: number | null;
+    hasUnlinkedAwaitingMessage?: boolean;
+  }
 ): ResolvePayloadKeyResult {
   const open = pickOpenPayloadRowAmong(rows);
+  const newSend = options.hasUnlinkedAwaitingMessage === true;
 
-  if (options.messagePayloadIndex != null) {
+  // A genuine new send carries a freshly prepared, unlinked awaiting message.
+  // The `messagePayloadIndex` hint is derived from prior (now terminal) linked
+  // messages and must not pull the event back onto a closed row; only apply the
+  // hint for late duplicates (no unlinked awaiting message).
+  if (!newSend && options.messagePayloadIndex != null) {
     const linked = rows.find((r) => r.index === options.messagePayloadIndex);
     if (linked) {
       const senderEvent = eventKind === "UnderpaidBatch" || eventKind === "SendPayload";
-      if (isPayloadRowOpen(linked) || senderEvent) {
+      // A closed hinted row is only reused as a replay fallback when no open
+      // row exists. With multiple rows per payload id the hint resolves to the
+      // LOWEST linked index, which may be a prior completed send - the event
+      // must then route to the open row via the per-event logic below.
+      if (isPayloadRowOpen(linked) || (senderEvent && !open)) {
         return { action: "mutate", index: linked.index };
       }
     }
@@ -260,22 +292,33 @@ export function resolvePayloadKeyForEvent(
         const unsent = pickLowestUnsentRowAmong(rows);
         if (unsent) return { action: "mutate", index: unsent.index };
       }
-      {
-        const highest = highestPayloadRowAmong(rows);
-        if (highest && isPayloadSent(highest)) return { action: "defer" };
-      }
+      // A new send with all prior rows sent allocates a fresh index; defer is
+      // reserved for late duplicates, which carry no unlinked awaiting message.
+      if (newSend) return { action: "create", index: nextPayloadIndex(rows) };
       return { action: "defer" };
 
     case "RepayBatch":
       if (open) return { action: "mutate", index: open.index };
       return { action: "defer" };
 
-    case "SendPayload":
+    case "SendPayload": {
+      // Genuine new send (paid path, unlinked message from this tx's
+      // PrepareMessage): never reuse an existing row - a pending underpaid row
+      // belongs to another instance awaiting its own RepayBatch -> SendPayload.
+      if (newSend) {
+        return { action: "create", index: nextPayloadIndex(rows) };
+      }
+      // Repay path / adapter rounds: the row being sent is the open unsent one
+      // (repaid underpaid instance); otherwise the open in-transit row (proof
+      // rounds re-emit SendPayload for an already-sent payload).
+      const openUnsent = pickLowestOpenUnsentRowAmong(rows);
+      if (openUnsent) return { action: "mutate", index: openUnsent.index };
       if (open) return { action: "mutate", index: open.index };
       if (rows.length === 0) return { action: "create", index: 0 };
       return options.deferAllowed
         ? { action: "defer" }
-        : { action: "create", index: nextPayloadIndexWhenAllClosed(rows) };
+        : { action: "create", index: nextPayloadIndex(rows) };
+    }
 
     case "HandlePayload": {
       const openSent = rows
@@ -383,6 +426,7 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
     const rowData = rows.map((r) => r.read());
 
     let messagePayloadIndex: number | null = null;
+    let unlinkedAwaiting = false;
     if (options.messageIds?.length) {
       const byId = await CrosschainMessageService.loadCrosschainMessagesByMessageIds(
         context,
@@ -390,16 +434,24 @@ export class CrosschainPayloadService extends Service<typeof CrosschainPayload> 
       );
       const flat = [...byId.values()].flat().map((r) => r.read());
       messagePayloadIndex = payloadIndexFromMessages(flat);
+      unlinkedAwaiting = hasUnlinkedAwaitingMessage(flat);
     }
 
     serviceLog(
       "CrosschainPayload resolvePayloadKey",
-      expandInlineObject({ payloadId, eventKind, messagePayloadIndex, rowCount: rowData.length })
+      expandInlineObject({
+        payloadId,
+        eventKind,
+        messagePayloadIndex,
+        unlinkedAwaiting,
+        rowCount: rowData.length,
+      })
     );
 
     return resolvePayloadKeyForEvent(eventKind, rowData, {
       deferAllowed: options.deferAllowed,
       messagePayloadIndex,
+      hasUnlinkedAwaitingMessage: unlinkedAwaiting,
     });
   }
 

--- a/test/unit/parity/crosschain-index.test.ts
+++ b/test/unit/parity/crosschain-index.test.ts
@@ -33,7 +33,7 @@ function isPayloadRowOpen(row: PayloadRowForIndex): boolean {
   return !isPayloadRowClosed(row);
 }
 
-function nextPayloadIndexWhenAllClosed(rows: PayloadRowForIndex[]): number {
+function nextPayloadIndex(rows: PayloadRowForIndex[]): number {
   if (rows.length === 0) return 0;
   return Math.max(...rows.map((r) => r.index)) + 1;
 }
@@ -72,13 +72,13 @@ describe("pickOpenPayloadRowAmong", () => {
   });
 });
 
-describe("nextPayloadIndexWhenAllClosed", () => {
+describe("nextPayloadIndex", () => {
   it("returns 0 for empty", () => {
-    expect(nextPayloadIndexWhenAllClosed([])).toBe(0);
+    expect(nextPayloadIndex([])).toBe(0);
   });
 
   it("returns MAX+1", () => {
-    expect(nextPayloadIndexWhenAllClosed([payload(0), payload(2)])).toBe(3);
+    expect(nextPayloadIndex([payload(0), payload(2)])).toBe(3);
   });
 });
 
@@ -116,11 +116,15 @@ describe("resolvePayloadKeyForEvent", () => {
     expect(key).toEqual({ action: "mutate", index: 0 });
   });
 
-  it("late UnderpaidBatch reuses index 0 via message hint when linked", () => {
+  it("replayed UnderpaidBatch (no unlinked message) reuses the closed hinted row", () => {
+    // Late duplicate of an already-linked batch: no freshly prepared unlinked
+    // message exists, so the messagePayloadIndex hint legitimately reuses the
+    // existing (possibly terminal) row instead of allocating a new index.
     const rows = [payload(0, { completedAt: t })];
     const key = resolvePayloadKeyForEvent("UnderpaidBatch", rows, {
       deferAllowed: false,
       messagePayloadIndex: 0,
+      hasUnlinkedAwaitingMessage: false,
     });
     expect(key).toEqual({ action: "mutate", index: 0 });
   });

--- a/test/unit/parity/crosschain-index.test.ts
+++ b/test/unit/parity/crosschain-index.test.ts
@@ -177,11 +177,60 @@ describe("resolvePayloadKeyForEvent", () => {
     expect(key).toEqual({ action: "defer" });
   });
 
-  it("uses message payloadIndex hint when row is open", () => {
+  it("uses message payloadIndex hint when the hinted open row is the only candidate", () => {
+    const rows = [payload(0, { completedAt: t }), payload(1, { sentAt: t })];
+    const key = resolvePayloadKeyForEvent("RepayBatch", rows, {
+      deferAllowed: false,
+      messagePayloadIndex: 1,
+    });
+    expect(key).toEqual({ action: "mutate", index: 1 });
+  });
+
+  it("RepayBatch ignores a hint pointing at a sent row when an open unsent row awaits its repay", () => {
+    // PR #465 review Gap A: a repay always targets an underpaid (unsent)
+    // instance - the min-based hint must not route it onto the older
+    // in-transit row.
     const rows = [payload(0), payload(1, { sentAt: t })];
     const key = resolvePayloadKeyForEvent("RepayBatch", rows, {
       deferAllowed: false,
       messagePayloadIndex: 1,
+    });
+    expect(key).toEqual({ action: "mutate", index: 0 });
+  });
+
+  it("RepayBatch follows the row sent by the current tx even when an unsent row exists", () => {
+    // Same-tx rule: Gateway.repay emits RepayBatch after _send, so the repaid
+    // row already carries this tx's hash and beats the prefer-unsent fallback.
+    const txHash = `0x${"cd".repeat(32)}` as const;
+    const rows = [payload(0), { ...payload(1, { sentAt: t }), sentAtTxHash: txHash }];
+    const key = resolvePayloadKeyForEvent("RepayBatch", rows, {
+      deferAllowed: false,
+      messagePayloadIndex: 1,
+      currentTxHash: txHash,
+    });
+    expect(key).toEqual({ action: "mutate", index: 1 });
+  });
+
+  it("SendPayload ignores a hint pointing at a sent open row when an open unsent row exists", () => {
+    // PR #465 review Gap A (send half): the repay-send of the underpaid
+    // instance must stamp sentAt on the unsent row, not no-op on row 0.
+    const rows = [payload(1), payload(0, { sentAt: t })];
+    const key = resolvePayloadKeyForEvent("SendPayload", rows, {
+      deferAllowed: false,
+      messagePayloadIndex: 0,
+    });
+    expect(key).toEqual({ action: "mutate", index: 1 });
+  });
+
+  it("SendPayload mutates the row it sent in the same tx (adapter proof round)", () => {
+    // PR #465 review Gap B: adapter #2's SendPayload in the same tx must not
+    // stamp sentAt on a pending underpaid row the hint points at.
+    const txHash = `0x${"ef".repeat(32)}` as const;
+    const rows = [payload(0), { ...payload(1, { sentAt: t }), sentAtTxHash: txHash }];
+    const key = resolvePayloadKeyForEvent("SendPayload", rows, {
+      deferAllowed: false,
+      messagePayloadIndex: 0,
+      currentTxHash: txHash,
     });
     expect(key).toEqual({ action: "mutate", index: 1 });
   });

--- a/test/unit/parity/crosschain-payload-resend.test.ts
+++ b/test/unit/parity/crosschain-payload-resend.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUnlinkedAwaitingMessage,
+  payloadIndexFromMessages,
+  resolvePayloadKeyForEvent,
+  type PayloadEventKind,
+  type PayloadRowForIndex,
+  type ResolvePayloadKeyResult,
+} from "../../../src/services/CrosschainPayloadService";
+
+/**
+ * Regression coverage for repeated identical crosschain sends (same batch bytes
+ * => same payloadId / messageId). Observed on Avalanche mainnet tx
+ * 0xea262a48..., block 91614644 (log order: PrepareMessage then UnderpaidBatch,
+ * SendPayload arrives in a later relayer tx after RepayBatch).
+ *
+ * Methodology: `resolvePayloadKeyForEvent` inputs are NEVER hand-set. Each
+ * scenario simulates the exact handler sequence (PrepareMessage duplicate
+ * guard, UnderpaidBatch linking, SendPayload linkMessagesToPayload, RepayBatch,
+ * destination execute/complete) and derives `messagePayloadIndex` via
+ * `payloadIndexFromMessages` and the new-send signal via
+ * `hasUnlinkedAwaitingMessage` from the simulated message rows - exactly like
+ * `CrosschainPayloadService.resolvePayloadKey` does. This guarantees every
+ * tested input combination is reachable in production.
+ *
+ * Two distinct issues are covered:
+ *  - Issue 1 (UnderpaidBatch): a new identical send after the prior payload is
+ *    sent/completed must allocate a new payload index. Signal: PrepareMessage
+ *    created a fresh unlinked AwaitingBatchDelivery message.
+ *  - Issue 2 (SendPayload after RepayBatch): by then UnderpaidBatch has already
+ *    linked the new message, so the signal is false and the min-based
+ *    `payloadIndexFromMessages` hint points at the OLD completed row. The send
+ *    must mutate the open unsent row, not the hinted completed row.
+ */
+
+const PAYLOAD_ID = `0x${"ab".repeat(32)}` as const;
+
+const T0 = new Date("2026-07-30T17:00:00Z");
+/** Monotonic clock for scenario steps. */
+function ts(minutes: number): Date {
+  return new Date(T0.getTime() + minutes * 60_000);
+}
+
+type SimMessage = {
+  index: number;
+  status: "AwaitingBatchDelivery" | "Executed" | "Failed";
+  payloadId: `0x${string}` | null;
+  payloadIndex: number | null;
+  preparedAt: Date | null;
+};
+
+type SimRow = Required<PayloadRowForIndex>;
+
+/**
+ * Minimal source-side simulation of the crosschain handlers for a single
+ * repeated one-message batch. Mirrors:
+ * - gateway:PrepareMessage duplicate guard (skip when an unlinked awaiting
+ *   message exists) and message row creation,
+ * - gateway:UnderpaidBatch (resolve key, link first unlinked awaiting message,
+ *   upsert underpaidAt),
+ * - multiAdapter:SendPayload (resolve key, linkMessagesToPayload = link lowest
+ *   unlinked prepared message, upsert sentAt),
+ * - gateway:RepayBatch (resolve key only, no timestamp facts),
+ * - destination execution (lowest awaiting message -> Executed; rows whose
+ *   linked messages are all Executed get deliveredAt/completedAt).
+ * Timestamp upserts use COALESCE semantics (existing value wins).
+ */
+class SendSim {
+  readonly msgs: SimMessage[] = [];
+  readonly rows: SimRow[] = [];
+
+  /** Derives resolvePayloadKey inputs from state, like the real service does. */
+  resolve(eventKind: PayloadEventKind, deferAllowed = false): ResolvePayloadKeyResult {
+    return resolvePayloadKeyForEvent(eventKind, this.rows, {
+      deferAllowed,
+      messagePayloadIndex: payloadIndexFromMessages(this.msgs),
+      hasUnlinkedAwaitingMessage: hasUnlinkedAwaitingMessage(this.msgs),
+    });
+  }
+
+  /** gateway:PrepareMessage - duplicate guard, then insert unlinked message. */
+  prepareMessage(at: Date): "created" | "skipped" {
+    const dup = this.msgs.some(
+      (m) => m.status === "AwaitingBatchDelivery" && m.payloadId == null
+    );
+    if (dup) return "skipped";
+    this.msgs.push({
+      index: this.msgs.length,
+      status: "AwaitingBatchDelivery",
+      payloadId: null,
+      payloadIndex: null,
+      preparedAt: at,
+    });
+    return "created";
+  }
+
+  /** gateway:UnderpaidBatch - resolve, link first unlinked awaiting, underpaidAt. */
+  underpaidBatch(at: Date): ResolvePayloadKeyResult {
+    const key = this.resolve("UnderpaidBatch");
+    if (key.action === "defer") return key;
+    const pending = this.msgs.find(
+      (m) => m.status === "AwaitingBatchDelivery" && m.payloadId == null && m.preparedAt != null
+    );
+    if (pending) {
+      pending.payloadId = PAYLOAD_ID;
+      pending.payloadIndex = key.index;
+    }
+    this.upsertRow(key, { underpaidAt: at });
+    return key;
+  }
+
+  /** gateway:RepayBatch - resolve only (facts carry no lifecycle timestamp). */
+  repayBatch(): ResolvePayloadKeyResult {
+    return this.resolve("RepayBatch");
+  }
+
+  /** multiAdapter:SendPayload - resolve, link lowest unlinked message, sentAt. */
+  sendPayload(at: Date): ResolvePayloadKeyResult {
+    const key = this.resolve("SendPayload");
+    if (key.action === "defer") return key;
+    const unlinked = this.msgs
+      .filter((m) => m.payloadId == null && m.payloadIndex == null && m.preparedAt != null)
+      .sort((a, b) => a.index - b.index)[0];
+    if (unlinked) {
+      unlinked.payloadId = PAYLOAD_ID;
+      unlinked.payloadIndex = key.index;
+    }
+    this.upsertRow(key, { sentAt: at });
+    return key;
+  }
+
+  /** Destination side: execute lowest awaiting message, complete finished rows. */
+  destExecuteAndComplete(at: Date): void {
+    const next = this.msgs
+      .filter((m) => m.status === "AwaitingBatchDelivery")
+      .sort((a, b) => a.index - b.index)[0];
+    if (next) next.status = "Executed";
+    for (const row of this.rows) {
+      const linked = this.msgs.filter((m) => m.payloadIndex === row.index);
+      if (linked.length > 0 && linked.every((m) => m.status === "Executed")) {
+        row.deliveredAt ??= at;
+        row.completedAt ??= at;
+      }
+    }
+  }
+
+  /** Applies a resolved key with COALESCE timestamp semantics. */
+  private upsertRow(
+    key: Extract<ResolvePayloadKeyResult, { action: "mutate" | "create" }>,
+    facts: Partial<Pick<SimRow, "underpaidAt" | "sentAt">>
+  ): void {
+    if (key.action === "create") {
+      this.rows.push({
+        index: key.index,
+        underpaidAt: facts.underpaidAt ?? null,
+        sentAt: facts.sentAt ?? null,
+        deliveredAt: null,
+        partiallyFailedAt: null,
+        completedAt: null,
+      });
+      return;
+    }
+    const row = this.rows.find((r) => r.index === key.index);
+    if (!row) throw new Error(`mutate on missing row index ${key.index}`);
+    if (facts.underpaidAt) row.underpaidAt ??= facts.underpaidAt;
+    if (facts.sentAt) row.sentAt ??= facts.sentAt;
+  }
+}
+
+describe("hasUnlinkedAwaitingMessage", () => {
+  it("returns true when a freshly prepared message is not yet linked to a payload", () => {
+    expect(
+      hasUnlinkedAwaitingMessage([
+        { payloadIndex: 0, payloadId: PAYLOAD_ID, status: "Executed", preparedAt: ts(0) },
+        { payloadIndex: null, payloadId: null, status: "AwaitingBatchDelivery", preparedAt: ts(60) },
+      ])
+    ).toBe(true);
+  });
+
+  it("returns false when every message is already linked to a payload", () => {
+    expect(
+      hasUnlinkedAwaitingMessage([
+        { payloadIndex: 0, payloadId: PAYLOAD_ID, status: "AwaitingBatchDelivery", preparedAt: ts(0) },
+      ])
+    ).toBe(false);
+  });
+
+  it("returns false when the unlinked message was already executed", () => {
+    expect(
+      hasUnlinkedAwaitingMessage([
+        { payloadIndex: null, payloadId: null, status: "Executed", preparedAt: ts(0) },
+      ])
+    ).toBe(false);
+  });
+
+  it("returns false when the awaiting message was never prepared (no preparedAt)", () => {
+    expect(
+      hasUnlinkedAwaitingMessage([
+        { payloadIndex: null, payloadId: null, status: "AwaitingBatchDelivery", preparedAt: null },
+      ])
+    ).toBe(false);
+  });
+});
+
+describe("scenario: first send of a batch (baseline flows)", () => {
+  it("a paid send creates payload index 0 and completes after destination execution", () => {
+    const sim = new SendSim();
+    expect(sim.prepareMessage(ts(0))).toBe("created");
+    expect(sim.sendPayload(ts(0))).toEqual({ action: "create", index: 0 });
+    sim.destExecuteAndComplete(ts(10));
+    expect(sim.rows[0]!.completedAt).not.toBeNull();
+    expect(sim.msgs[0]!.payloadIndex).toBe(0);
+  });
+
+  it("an underpaid send stays on payload index 0 through underpaid, repay, and send", () => {
+    const sim = new SendSim();
+    expect(sim.prepareMessage(ts(0))).toBe("created");
+    expect(sim.underpaidBatch(ts(0))).toEqual({ action: "create", index: 0 });
+    expect(sim.repayBatch()).toEqual({ action: "mutate", index: 0 });
+    expect(sim.sendPayload(ts(5))).toEqual({ action: "mutate", index: 0 });
+    sim.destExecuteAndComplete(ts(10));
+    expect(sim.rows).toHaveLength(1);
+    expect(sim.rows[0]!.completedAt).not.toBeNull();
+  });
+});
+
+describe("scenario: identical batch sent again after the first payload completed", () => {
+  /** Runs one full underpaid send cycle to completion. */
+  function completeUnderpaidCycle(sim: SendSim, startMin: number): void {
+    sim.prepareMessage(ts(startMin));
+    sim.underpaidBatch(ts(startMin));
+    sim.repayBatch();
+    sim.sendPayload(ts(startMin + 5));
+    sim.destExecuteAndComplete(ts(startMin + 10));
+  }
+
+  it("UnderpaidBatch of the resend creates payload index 1 instead of mutating the completed row (Avalanche bug tx)", () => {
+    const sim = new SendSim();
+    completeUnderpaidCycle(sim, 0);
+
+    // Second identical requestRedeem: PrepareMessage passes the duplicate
+    // guard (msg 0 is Executed) and creates msg 1 unlinked.
+    expect(sim.prepareMessage(ts(60))).toBe("created");
+    expect(sim.underpaidBatch(ts(60))).toEqual({ action: "create", index: 1 });
+    expect(sim.msgs[1]!.payloadIndex).toBe(1);
+    expect(sim.rows).toHaveLength(2);
+    // The completed row is untouched.
+    expect(sim.rows[0]!.completedAt).not.toBeNull();
+  });
+
+  it("SendPayload after RepayBatch mutates the new unsent row 1, even though the message hint points at completed row 0", () => {
+    const sim = new SendSim();
+    completeUnderpaidCycle(sim, 0);
+
+    sim.prepareMessage(ts(60));
+    sim.underpaidBatch(ts(60));
+    // At this point msg 1 is linked to index 1 -> the new-send signal is
+    // false and payloadIndexFromMessages returns min(0, 1) = 0 (the stale,
+    // completed row). Realistic post-RepayBatch state.
+    expect(hasUnlinkedAwaitingMessage(sim.msgs)).toBe(false);
+    expect(payloadIndexFromMessages(sim.msgs)).toBe(0);
+
+    expect(sim.repayBatch()).toEqual({ action: "mutate", index: 1 });
+    expect(sim.sendPayload(ts(65))).toEqual({ action: "mutate", index: 1 });
+    expect(sim.rows[1]!.sentAt).not.toBeNull();
+    // Completed row 0 keeps its original timestamps.
+    expect(sim.rows[0]!.sentAt).toEqual(ts(5));
+  });
+
+  it("a paid resend creates payload index 1 in the same transaction as its PrepareMessage", () => {
+    const sim = new SendSim();
+    completeUnderpaidCycle(sim, 0);
+
+    // Paid path: SendPayload fires in the same tx as PrepareMessage, before
+    // anything links msg 1 -> the new-send signal is true.
+    expect(sim.prepareMessage(ts(60))).toBe("created");
+    expect(hasUnlinkedAwaitingMessage(sim.msgs)).toBe(true);
+    expect(sim.sendPayload(ts(60))).toEqual({ action: "create", index: 1 });
+    expect(sim.msgs[1]!.payloadIndex).toBe(1);
+  });
+
+  it("a third identical resend creates payload index 2", () => {
+    const sim = new SendSim();
+    completeUnderpaidCycle(sim, 0);
+    completeUnderpaidCycle(sim, 60);
+    expect(sim.rows).toHaveLength(2);
+
+    expect(sim.prepareMessage(ts(120))).toBe("created");
+    expect(sim.underpaidBatch(ts(120))).toEqual({ action: "create", index: 2 });
+  });
+
+  it("a resend while the prior payload is still in transit creates a new index", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    sim.underpaidBatch(ts(0));
+    sim.repayBatch();
+    sim.sendPayload(ts(5));
+    // No destination execution yet: row 0 is InTransit, msg 0 still awaiting.
+
+    // PrepareMessage guard passes: msg 0 is awaiting but LINKED.
+    expect(sim.prepareMessage(ts(20))).toBe("created");
+    expect(sim.underpaidBatch(ts(20))).toEqual({ action: "create", index: 1 });
+  });
+});
+
+describe("scenario: the same batch is underpaid twice before any repay", () => {
+  it("the second UnderpaidBatch reuses the pending unsent row instead of creating a duplicate", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    expect(sim.underpaidBatch(ts(0))).toEqual({ action: "create", index: 0 });
+
+    // Second identical send, also underpaid, before any repay. msg 0 is
+    // awaiting but linked -> guard passes, msg 1 created unlinked.
+    expect(sim.prepareMessage(ts(10))).toBe("created");
+    expect(sim.underpaidBatch(ts(10))).toEqual({ action: "mutate", index: 0 });
+    // Both messages end up on the single pending row.
+    expect(sim.msgs[0]!.payloadIndex).toBe(0);
+    expect(sim.msgs[1]!.payloadIndex).toBe(0);
+    expect(sim.rows).toHaveLength(1);
+  });
+});
+
+describe("scenario: multiple adapters emit SendPayload for the same send (proof rounds)", () => {
+  it("the second adapter's SendPayload mutates the same in-transit row", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    sim.underpaidBatch(ts(0));
+    sim.repayBatch();
+    expect(sim.sendPayload(ts(5))).toEqual({ action: "mutate", index: 0 });
+    // Second adapter's SendPayload in the same tx: message already linked.
+    expect(sim.sendPayload(ts(5))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.rows).toHaveLength(1);
+  });
+});
+
+describe("scenario: a paid send happens while an underpaid instance is still pending", () => {
+  it("the paid send creates a new index and leaves the underpaid row waiting for its own repay", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    expect(sim.underpaidBatch(ts(0))).toEqual({ action: "create", index: 0 });
+
+    // Second identical send with enough gas: goes straight out via
+    // multiAdapter in the same tx as its PrepareMessage.
+    expect(sim.prepareMessage(ts(10))).toBe("created");
+    expect(hasUnlinkedAwaitingMessage(sim.msgs)).toBe(true);
+    expect(sim.sendPayload(ts(10))).toEqual({ action: "create", index: 1 });
+    // Pending underpaid instance keeps waiting for its own repay + send.
+    expect(sim.rows[0]!.sentAt).toBeNull();
+
+    expect(sim.repayBatch()).toEqual({ action: "mutate", index: 0 });
+    expect(sim.sendPayload(ts(20))).toEqual({ action: "mutate", index: 0 });
+  });
+});
+
+describe("defensive fallbacks for replayed events (states unreachable in the normal flow)", () => {
+  const completedRow: PayloadRowForIndex = {
+    index: 0,
+    underpaidAt: ts(0),
+    sentAt: ts(5),
+    deliveredAt: ts(10),
+    partiallyFailedAt: null,
+    completedAt: ts(10),
+  };
+
+  it("an UnderpaidBatch replay with every message already linked reuses the closed row the hint points at", () => {
+    // Unreachable in normal flow (PrepareMessage would have created an
+    // unlinked message first) - kept as a replay-safety fallback.
+    const key = resolvePayloadKeyForEvent("UnderpaidBatch", [completedRow], {
+      deferAllowed: false,
+      messagePayloadIndex: 0,
+      hasUnlinkedAwaitingMessage: false,
+    });
+    expect(key).toEqual({ action: "mutate", index: 0 });
+  });
+
+  it("an UnderpaidBatch replay with no message hint and all rows already sent defers", () => {
+    const key = resolvePayloadKeyForEvent("UnderpaidBatch", [completedRow], {
+      deferAllowed: false,
+      hasUnlinkedAwaitingMessage: false,
+    });
+    expect(key).toEqual({ action: "defer" });
+  });
+});
+
+describe("UnderpaidBatch resend across every payload lifecycle stage", () => {
+  /** Prior-cycle message linked to row 0 plus a fresh unlinked message. */
+  function resendMessages(priorStatus: SimMessage["status"]): SimMessage[] {
+    return [
+      { index: 0, status: priorStatus, payloadId: PAYLOAD_ID, payloadIndex: 0, preparedAt: ts(0) },
+      { index: 1, status: "AwaitingBatchDelivery", payloadId: null, payloadIndex: null, preparedAt: ts(60) },
+    ];
+  }
+
+  function resolveResend(row: PayloadRowForIndex, msgs: SimMessage[]): ResolvePayloadKeyResult {
+    return resolvePayloadKeyForEvent("UnderpaidBatch", [row], {
+      deferAllowed: false,
+      messagePayloadIndex: payloadIndexFromMessages(msgs),
+      hasUnlinkedAwaitingMessage: hasUnlinkedAwaitingMessage(msgs),
+    });
+  }
+
+  const sentStages: [string, PayloadRowForIndex, SimMessage["status"]][] = [
+    ["InTransit", { index: 0, underpaidAt: ts(0), sentAt: ts(5), deliveredAt: null, partiallyFailedAt: null, completedAt: null }, "AwaitingBatchDelivery"],
+    ["Delivered", { index: 0, underpaidAt: ts(0), sentAt: ts(5), deliveredAt: ts(10), partiallyFailedAt: null, completedAt: null }, "AwaitingBatchDelivery"],
+    ["PartiallyFailed", { index: 0, underpaidAt: ts(0), sentAt: ts(5), deliveredAt: ts(10), partiallyFailedAt: ts(10), completedAt: null }, "Failed"],
+    ["Completed", { index: 0, underpaidAt: ts(0), sentAt: ts(5), deliveredAt: ts(10), partiallyFailedAt: null, completedAt: ts(10) }, "Executed"],
+  ];
+
+  for (const [stage, row, priorStatus] of sentStages) {
+    it(`prior payload ${stage}: a resend creates payload index 1`, () => {
+      expect(resolveResend(row, resendMessages(priorStatus))).toEqual({
+        action: "create",
+        index: 1,
+      });
+    });
+  }
+
+  it("prior payload Underpaid (never sent): a resend reuses the pending row", () => {
+    const row: PayloadRowForIndex = {
+      index: 0,
+      underpaidAt: ts(0),
+      sentAt: null,
+      deliveredAt: null,
+      partiallyFailedAt: null,
+      completedAt: null,
+    };
+    expect(resolveResend(row, resendMessages("AwaitingBatchDelivery"))).toEqual({
+      action: "mutate",
+      index: 0,
+    });
+  });
+});

--- a/test/unit/parity/crosschain-payload-resend.test.ts
+++ b/test/unit/parity/crosschain-payload-resend.test.ts
@@ -31,6 +31,15 @@ import {
  *    linked the new message, so the signal is false and the min-based
  *    `payloadIndexFromMessages` hint points at the OLD completed row. The send
  *    must mutate the open unsent row, not the hinted completed row.
+ *
+ * PR #465 review follow-up: when the hinted row is OPEN the hint used to win
+ * unconditionally, misrouting (a) the repay of a second underpaid instance
+ * while the prior instance is InTransit / PartiallyFailed, and (b) a second
+ * adapter's SendPayload (MultiAdapter emits one per adapter) while an
+ * unrelated underpaid row is pending. Disambiguation is deterministic via the
+ * event tx hash: a row with `sentAtTxHash` equal to the current tx hash was
+ * sent by this tx (proof round / same-tx RepayBatch); otherwise a sender event
+ * must prefer the open unsent row over a hint pointing at an already-sent row.
  */
 
 const PAYLOAD_ID = `0x${"ab".repeat(32)}` as const;
@@ -39,6 +48,11 @@ const T0 = new Date("2026-07-30T17:00:00Z");
 /** Monotonic clock for scenario steps. */
 function ts(minutes: number): Date {
   return new Date(T0.getTime() + minutes * 60_000);
+}
+
+/** Deterministic tx hash for scenario steps sharing (or not) a transaction. */
+function tx(n: number): `0x${string}` {
+  return `0x${n.toString(16).padStart(64, "0")}` as `0x${string}`;
 }
 
 type SimMessage = {
@@ -70,11 +84,16 @@ class SendSim {
   readonly rows: SimRow[] = [];
 
   /** Derives resolvePayloadKey inputs from state, like the real service does. */
-  resolve(eventKind: PayloadEventKind, deferAllowed = false): ResolvePayloadKeyResult {
+  resolve(
+    eventKind: PayloadEventKind,
+    deferAllowed = false,
+    currentTxHash: `0x${string}` | null = null
+  ): ResolvePayloadKeyResult {
     return resolvePayloadKeyForEvent(eventKind, this.rows, {
       deferAllowed,
       messagePayloadIndex: payloadIndexFromMessages(this.msgs),
       hasUnlinkedAwaitingMessage: hasUnlinkedAwaitingMessage(this.msgs),
+      currentTxHash,
     });
   }
 
@@ -110,13 +129,13 @@ class SendSim {
   }
 
   /** gateway:RepayBatch - resolve only (facts carry no lifecycle timestamp). */
-  repayBatch(): ResolvePayloadKeyResult {
-    return this.resolve("RepayBatch");
+  repayBatch(txHash: `0x${string}` | null = null): ResolvePayloadKeyResult {
+    return this.resolve("RepayBatch", false, txHash);
   }
 
   /** multiAdapter:SendPayload - resolve, link lowest unlinked message, sentAt. */
-  sendPayload(at: Date): ResolvePayloadKeyResult {
-    const key = this.resolve("SendPayload");
+  sendPayload(at: Date, txHash: `0x${string}` | null = null): ResolvePayloadKeyResult {
+    const key = this.resolve("SendPayload", false, txHash);
     if (key.action === "defer") return key;
     const unlinked = this.msgs
       .filter((m) => m.payloadId == null && m.payloadIndex == null && m.preparedAt != null)
@@ -125,7 +144,7 @@ class SendSim {
       unlinked.payloadId = PAYLOAD_ID;
       unlinked.payloadIndex = key.index;
     }
-    this.upsertRow(key, { sentAt: at });
+    this.upsertRow(key, { sentAt: at, sentAtTxHash: txHash });
     return key;
   }
 
@@ -144,16 +163,35 @@ class SendSim {
     }
   }
 
+  /**
+   * Destination side: lowest awaiting message fails on execute. The linked row
+   * is delivered but partially failed - it stays open (completedAt null)
+   * indefinitely until a retry succeeds.
+   */
+  destFail(at: Date): void {
+    const next = this.msgs
+      .filter((m) => m.status === "AwaitingBatchDelivery")
+      .sort((a, b) => a.index - b.index)[0];
+    if (!next) return;
+    next.status = "Failed";
+    const row = this.rows.find((r) => r.index === next.payloadIndex);
+    if (row) {
+      row.deliveredAt ??= at;
+      row.partiallyFailedAt ??= at;
+    }
+  }
+
   /** Applies a resolved key with COALESCE timestamp semantics. */
   private upsertRow(
     key: Extract<ResolvePayloadKeyResult, { action: "mutate" | "create" }>,
-    facts: Partial<Pick<SimRow, "underpaidAt" | "sentAt">>
+    facts: Partial<Pick<SimRow, "underpaidAt" | "sentAt" | "sentAtTxHash">>
   ): void {
     if (key.action === "create") {
       this.rows.push({
         index: key.index,
         underpaidAt: facts.underpaidAt ?? null,
         sentAt: facts.sentAt ?? null,
+        sentAtTxHash: facts.sentAt ? (facts.sentAtTxHash ?? null) : null,
         deliveredAt: null,
         partiallyFailedAt: null,
         completedAt: null,
@@ -163,7 +201,12 @@ class SendSim {
     const row = this.rows.find((r) => r.index === key.index);
     if (!row) throw new Error(`mutate on missing row index ${key.index}`);
     if (facts.underpaidAt) row.underpaidAt ??= facts.underpaidAt;
-    if (facts.sentAt) row.sentAt ??= facts.sentAt;
+    if (facts.sentAt) {
+      // timestamperWithChain("sent", ...) writes sentAt + sentAtTxHash together;
+      // COALESCE keeps the first writer for both.
+      if (row.sentAt == null) row.sentAtTxHash = facts.sentAtTxHash ?? null;
+      row.sentAt ??= facts.sentAt;
+    }
   }
 }
 
@@ -325,11 +368,120 @@ describe("scenario: multiple adapters emit SendPayload for the same send (proof 
     const sim = new SendSim();
     sim.prepareMessage(ts(0));
     sim.underpaidBatch(ts(0));
-    sim.repayBatch();
-    expect(sim.sendPayload(ts(5))).toEqual({ action: "mutate", index: 0 });
+    sim.repayBatch(tx(1));
+    expect(sim.sendPayload(ts(5), tx(1))).toEqual({ action: "mutate", index: 0 });
     // Second adapter's SendPayload in the same tx: message already linked.
-    expect(sim.sendPayload(ts(5))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.sendPayload(ts(5), tx(1))).toEqual({ action: "mutate", index: 0 });
     expect(sim.rows).toHaveLength(1);
+  });
+
+  it("a second adapter's SendPayload while an unrelated underpaid row is pending mutates the row sent in this tx, not the underpaid one", () => {
+    const sim = new SendSim();
+    // Instance 0: underpaid, waiting for its own repay.
+    sim.prepareMessage(ts(0));
+    expect(sim.underpaidBatch(ts(0))).toEqual({ action: "create", index: 0 });
+
+    // Instance 1: identical paid send via multiAdapter. MultiAdapter.send()
+    // loops over all configured adapters and emits one SendPayload each
+    // (MultiAdapter.sol), all in the same tx.
+    sim.prepareMessage(ts(10));
+    expect(sim.sendPayload(ts(10), tx(1))).toEqual({ action: "create", index: 1 });
+    // Adapter #2: msg 1 is linked by now, so the new-send signal is false and
+    // the min-based hint points at underpaid row 0. Row 1 carries this tx's
+    // hash - the proof round belongs to it.
+    expect(sim.sendPayload(ts(10), tx(1))).toEqual({ action: "mutate", index: 1 });
+
+    // The underpaid row must not be stamped as sent by a foreign proof round.
+    expect(sim.rows[0]!.sentAt).toBeNull();
+    expect(sim.rows).toHaveLength(2);
+  });
+});
+
+describe("scenario: repay of an underpaid instance while the prior instance is still open", () => {
+  /** Row 0 sent and awaiting destination; row 1 underpaid pending repay. */
+  function setupInTransitPlusUnderpaid(sim: SendSim): void {
+    sim.prepareMessage(ts(0));
+    sim.underpaidBatch(ts(0));
+    // On-chain repay tx order: _send (SendPayload) before emit RepayBatch.
+    expect(sim.sendPayload(ts(5), tx(1))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.repayBatch(tx(1))).toEqual({ action: "mutate", index: 0 });
+    // No destination execution: row 0 stays InTransit, msg 0 awaiting.
+
+    sim.prepareMessage(ts(20));
+    expect(sim.underpaidBatch(ts(20))).toEqual({ action: "create", index: 1 });
+  }
+
+  it("the repay tx routes to the underpaid row 1, not the in-transit row 0 the hint points at", () => {
+    const sim = new SendSim();
+    setupInTransitPlusUnderpaid(sim);
+
+    // Repay tx for instance 1: no PrepareMessage, both messages linked, so
+    // the hint resolves to min(0, 1) = 0 while row 0 is still open.
+    expect(sim.sendPayload(ts(30), tx(2))).toEqual({ action: "mutate", index: 1 });
+    expect(sim.repayBatch(tx(2))).toEqual({ action: "mutate", index: 1 });
+
+    expect(sim.rows[1]!.sentAt).toEqual(ts(30));
+    expect(sim.rows[0]!.sentAt).toEqual(ts(5));
+  });
+
+  it("same with RepayBatch and SendPayload in separate txs (v3 relayer ordering)", () => {
+    const sim = new SendSim();
+    setupInTransitPlusUnderpaid(sim);
+
+    // Observed on Avalanche: RepayBatch tx first, SendPayload in a later
+    // relayer tx. A repay always targets an underpaid (unsent) instance.
+    expect(sim.repayBatch(tx(2))).toEqual({ action: "mutate", index: 1 });
+    expect(sim.sendPayload(ts(35), tx(3))).toEqual({ action: "mutate", index: 1 });
+
+    expect(sim.rows[1]!.sentAt).toEqual(ts(35));
+    expect(sim.rows[0]!.sentAt).toEqual(ts(5));
+  });
+
+  it("the repay tx routes to the underpaid row 1 while row 0 is PartiallyFailed (open indefinitely)", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    sim.underpaidBatch(ts(0));
+    expect(sim.sendPayload(ts(5), tx(1))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.repayBatch(tx(1))).toEqual({ action: "mutate", index: 0 });
+    // Destination execution fails: row 0 delivered + partially failed, open.
+    sim.destFail(ts(10));
+    expect(sim.rows[0]!.partiallyFailedAt).not.toBeNull();
+    expect(sim.rows[0]!.completedAt).toBeNull();
+
+    sim.prepareMessage(ts(60));
+    expect(sim.underpaidBatch(ts(60))).toEqual({ action: "create", index: 1 });
+
+    expect(sim.sendPayload(ts(70), tx(2))).toEqual({ action: "mutate", index: 1 });
+    expect(sim.repayBatch(tx(2))).toEqual({ action: "mutate", index: 1 });
+
+    expect(sim.rows[1]!.sentAt).toEqual(ts(70));
+    expect(sim.rows[0]!.sentAt).toEqual(ts(5));
+  });
+});
+
+describe("scenario: double-underpaid batch collapses onto one row through both repays and deliveries", () => {
+  it("both repay txs mutate row 0 and the row completes after both message instances execute", () => {
+    const sim = new SendSim();
+    sim.prepareMessage(ts(0));
+    expect(sim.underpaidBatch(ts(0))).toEqual({ action: "create", index: 0 });
+    sim.prepareMessage(ts(1));
+    expect(sim.underpaidBatch(ts(1))).toEqual({ action: "mutate", index: 0 });
+
+    // First repay tx (SendPayload before RepayBatch, on-chain order).
+    expect(sim.sendPayload(ts(5), tx(1))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.repayBatch(tx(1))).toEqual({ action: "mutate", index: 0 });
+
+    // Second repay tx: all messages linked to row 0, no open unsent row -
+    // the intended single-row collapse keeps mutating row 0.
+    expect(sim.sendPayload(ts(6), tx(2))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.repayBatch(tx(2))).toEqual({ action: "mutate", index: 0 });
+    expect(sim.rows).toHaveLength(1);
+
+    // Destination executes both message instances; row 0 completes.
+    sim.destExecuteAndComplete(ts(10));
+    expect(sim.rows[0]!.completedAt).toBeNull();
+    sim.destExecuteAndComplete(ts(11));
+    expect(sim.rows[0]!.completedAt).not.toBeNull();
   });
 });
 
@@ -391,6 +543,7 @@ describe("UnderpaidBatch resend across every payload lifecycle stage", () => {
     ];
   }
 
+  /** Resolves an UnderpaidBatch resend against one prior row, deriving hints from msgs. */
   function resolveResend(row: PayloadRowForIndex, msgs: SimMessage[]): ResolvePayloadKeyResult {
     return resolvePayloadKeyForEvent("UnderpaidBatch", [row], {
       deferAllowed: false,


### PR DESCRIPTION
## Summary

- Repeated sends with identical batch bytes share a payloadId. Once the prior payload was sent or completed, the indexer mutated the old row instead of creating a new index, so the resend's payload row was missing (Avalanche tx 0xea262a48...af7554, block 91614644).
- UnderpaidBatch: new sends are detected via the freshly prepared unlinked message from PrepareMessage and allocate MAX(index)+1 instead of following the stale message hint.
- SendPayload after RepayBatch: mutates the open unsent row; a closed hinted row is only reused when no open row exists (replay fallback).
- New scenario-driven tests simulate the exact handler sequences (PrepareMessage duplicate guard, message linking, repay, destination execution), so every tested input is reachable in production. Covers baselines, resends at every lifecycle stage, double underpaid, adapter proof rounds, and replay fallbacks.

Fixes #463
Fixes #464

## Notes

- Full reindex required to backfill historical rows.
- Known ambiguity (hint at an open in-transit row while an unsent row exists: adapter proof rounds vs repay-send of another instance) is documented in the code.

## Test plan

- pnpm vitest run test/unit/ (188 passing, 21 new)
- pnpm typecheck and pnpm lint clean