### PR TITLE
fix: monad explorer URL 404s (#470)

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -309,7 +309,7 @@ export const explorerUrls = {
   "1": "https://etherscan.io",
   "98866": "https://explorer.plume.org",
   "56": "https://bscscan.com",
-  "143": "https://monad.socialscan.io",
+  "143": "https://monadvision.com",
   "999": "https://hyperevmscan.io",
   "10": "https://optimistic.etherscan.io/",
 };


### PR DESCRIPTION
## Summary
- `explorerUrls["143"]` in `src/chains.ts` pointed at `https://monad.socialscan.io`, which 404s on token/address pages.
- Switched to `https://monadvision.com` so explorer links resolve.

Closes #470.

## Test plan
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm typecheck` (clean)
- [ ] Spot-check a token link built from the new base, e.g. `https://monadvision.com/token/0x2fabf1c7843d63c00c5c9c0377d8cf1a3245`