### PR TITLE
fix: deprecate ipfs.centrifuge.io gateway

### DIFF
--- a/environments/main-s.yaml
+++ b/environments/main-s.yaml
@@ -2,7 +2,7 @@ global:
   env:
     ENVIRONMENT: "mainnet"
     SELECTED_NETWORKS: "42161,8453,1,98866,43114,56,10,143,999,1672"
-    REGISTRY_URL: "https://ipfs.centrifuge.io/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
+    REGISTRY_URL: "https://centrifuge-files.mypinata.cloud/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
     PONDER_RPC_URL_1: "http://cfg-api-erpc:4000/main/evm/1"
     PONDER_RPC_URL_10: "http://cfg-api-erpc:4000/main/evm/10"
     PONDER_RPC_URL_8453: "http://cfg-api-erpc:4000/main/evm/8453"

--- a/environments/main-us-s.yaml
+++ b/environments/main-us-s.yaml
@@ -2,7 +2,7 @@ global:
   env:
     ENVIRONMENT: "mainnet"
     SELECTED_NETWORKS: "42161,8453,1,98866,43114,56,10,143,999,1672"
-    REGISTRY_URL: "https://ipfs.centrifuge.io/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
+    REGISTRY_URL: "https://centrifuge-files.mypinata.cloud/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
     PONDER_RPC_URL_1: "http://cfg-api-erpc-us:4000/main/evm/1"
     PONDER_RPC_URL_10: "http://cfg-api-erpc-us:4000/main/evm/10"
     PONDER_RPC_URL_8453: "http://cfg-api-erpc-us:4000/main/evm/8453"

--- a/environments/main-us.yaml
+++ b/environments/main-us.yaml
@@ -2,7 +2,7 @@ global:
   env:
     ENVIRONMENT: "mainnet"
     SELECTED_NETWORKS: "42161,8453,1,98866,43114,56,10,143,999,1672"
-    REGISTRY_URL: "https://ipfs.centrifuge.io/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
+    REGISTRY_URL: "https://centrifuge-files.mypinata.cloud/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
     PONDER_RPC_URL_1: "http://cfg-api-erpc-us:4000/main/evm/1"
     PONDER_RPC_URL_10: "http://cfg-api-erpc-us:4000/main/evm/10"
     PONDER_RPC_URL_8453: "http://cfg-api-erpc-us:4000/main/evm/8453"

--- a/environments/main.yaml
+++ b/environments/main.yaml
@@ -2,7 +2,7 @@ global:
   env:
     ENVIRONMENT: "mainnet"
     SELECTED_NETWORKS: "42161,8453,1,98866,43114,56,10,143,999,1672"
-    REGISTRY_URL: "https://ipfs.centrifuge.io/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
+    REGISTRY_URL: "https://centrifuge-files.mypinata.cloud/ipfs/bafkreigcjb6hyhpkmdgzdlcpeqdta36tqixwml3ovgxfrn56psnqhspqcu"
     PONDER_RPC_URL_1: "http://cfg-api-erpc:4000/main/evm/1"
     PONDER_RPC_URL_10: "http://cfg-api-erpc:4000/main/evm/10"
     PONDER_RPC_URL_8453: "http://cfg-api-erpc:4000/main/evm/8453"

--- a/scripts/fetch-registry.mjs
+++ b/scripts/fetch-registry.mjs
@@ -33,7 +33,7 @@ const network = argNetwork ?? envNetwork ?? "mainnet";
 
 const {
   REGISTRY_URL = network === "mainnet" ? "https://registry.centrifuge.io/" : "https://registry.testnet.centrifuge.io/",
-  IPFS_GATEWAY = "https://ipfs.centrifuge.io/ipfs",
+  IPFS_GATEWAY = "https://centrifuge-files.mypinata.cloud/ipfs",
   IPFS_HASH
 } = process.env;
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -316,24 +316,24 @@ export const explorerUrls = {
 
 // Icons definitions
 export const chainIcons = {
-  "1": "https://ipfs.centrifuge.io/ipfs/bafkreihk753r3oksmw5pburcz4dxq2xazsarihdkeae2ilt7tc7lj2hggm",
+  "1": "https://centrifuge-files.mypinata.cloud/ipfs/bafkreihk753r3oksmw5pburcz4dxq2xazsarihdkeae2ilt7tc7lj2hggm",
   "8453":
-    "https://ipfs.centrifuge.io/ipfs/bafkreifpdqjq6jvh4xat54ymcue6p4n24ifc3gzz2446cipumiwbz7ybu4",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreifpdqjq6jvh4xat54ymcue6p4n24ifc3gzz2446cipumiwbz7ybu4",
   "42161":
-    "https://ipfs.centrifuge.io/ipfs/bafkreiemrnwrwcxbwho3ut6x3k4zv4jerowpwnynovt6sbc7kgqbfknq7a",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreiemrnwrwcxbwho3ut6x3k4zv4jerowpwnynovt6sbc7kgqbfknq7a",
   "98866":
-    "https://ipfs.centrifuge.io/ipfs/bafkreiecr63jf4mvgylcnxry3wsds6cdmjsnzcybjffmvcpxhes6qwfngy",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreiecr63jf4mvgylcnxry3wsds6cdmjsnzcybjffmvcpxhes6qwfngy",
   "43114":
-    "https://ipfs.centrifuge.io/ipfs/bafkreiaxodsgromeeaihu44fazsxdopkrqvinqzhyfxvx5mrbcmduqdfpq",
-  "56": "https://ipfs.centrifuge.io/ipfs/bafkreidiypdacfywbuokj7r3e7td5bs6ojkh37ycz3uwfcbd34xka2qtai",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreiaxodsgromeeaihu44fazsxdopkrqvinqzhyfxvx5mrbcmduqdfpq",
+  "56": "https://centrifuge-files.mypinata.cloud/ipfs/bafkreidiypdacfywbuokj7r3e7td5bs6ojkh37ycz3uwfcbd34xka2qtai",
   "11155111":
-    "https://ipfs.centrifuge.io/ipfs/bafkreihk753r3oksmw5pburcz4dxq2xazsarihdkeae2ilt7tc7lj2hggm",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreihk753r3oksmw5pburcz4dxq2xazsarihdkeae2ilt7tc7lj2hggm",
   "84532":
-    "https://ipfs.centrifuge.io/ipfs/bafkreifpdqjq6jvh4xat54ymcue6p4n24ifc3gzz2446cipumiwbz7ybu4",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreifpdqjq6jvh4xat54ymcue6p4n24ifc3gzz2446cipumiwbz7ybu4",
   "421614":
-    "https://ipfs.centrifuge.io/ipfs/bafkreiemrnwrwcxbwho3ut6x3k4zv4jerowpwnynovt6sbc7kgqbfknq7a",
-  "143": "https://ipfs.centrifuge.io/ipfs/QmX86URyeeYYR5DxcnKfYF7ApMeRQPC9JurZBTS9VBUiAH",
-  "999": "https://ipfs.centrifuge.io/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
-  "998": "https://ipfs.centrifuge.io/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
-  "10": "https://ipfs.centrifuge.io/ipfs/QmXR2gUAwJdEhH7MAqEqd6NTGB58XibiKvtE3TUoe6CcMK",
+    "https://centrifuge-files.mypinata.cloud/ipfs/bafkreiemrnwrwcxbwho3ut6x3k4zv4jerowpwnynovt6sbc7kgqbfknq7a",
+  "143": "https://centrifuge-files.mypinata.cloud/ipfs/QmX86URyeeYYR5DxcnKfYF7ApMeRQPC9JurZBTS9VBUiAH",
+  "999": "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
+  "998": "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
+  "10": "https://centrifuge-files.mypinata.cloud/ipfs/QmXR2gUAwJdEhH7MAqEqd6NTGB58XibiKvtE3TUoe6CcMK",
 };

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -332,8 +332,11 @@ export const chainIcons = {
     "https://centrifuge-files.mypinata.cloud/ipfs/bafkreifpdqjq6jvh4xat54ymcue6p4n24ifc3gzz2446cipumiwbz7ybu4",
   "421614":
     "https://centrifuge-files.mypinata.cloud/ipfs/bafkreiemrnwrwcxbwho3ut6x3k4zv4jerowpwnynovt6sbc7kgqbfknq7a",
-  "143": "https://centrifuge-files.mypinata.cloud/ipfs/QmX86URyeeYYR5DxcnKfYF7ApMeRQPC9JurZBTS9VBUiAH",
-  "999": "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
-  "998": "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
+  "143":
+    "https://centrifuge-files.mypinata.cloud/ipfs/QmX86URyeeYYR5DxcnKfYF7ApMeRQPC9JurZBTS9VBUiAH",
+  "999":
+    "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
+  "998":
+    "https://centrifuge-files.mypinata.cloud/ipfs/QmZnmSzzq3Jspa3HxUdk4JQAWgtAQtinBdDTBdAFn2jijX",
   "10": "https://centrifuge-files.mypinata.cloud/ipfs/QmXR2gUAwJdEhH7MAqEqd6NTGB58XibiKvtE3TUoe6CcMK",
 };

--- a/src/helpers/ipfs.ts
+++ b/src/helpers/ipfs.ts
@@ -1,13 +1,13 @@
 import fetch from "node-fetch";
 import { serviceError } from "./logger";
 
-const DEFAULT_IPFS_GATEWAY = "https://ipfs.centrifuge.io/ipfs/";
+const DEFAULT_IPFS_GATEWAY = "https://centrifuge-files.mypinata.cloud/ipfs/";
 const IPFS_GATEWAY = (process.env.IPFS_GATEWAY ?? DEFAULT_IPFS_GATEWAY).replace(/\/?$/, "/");
 
 /**
  * Fetches and parses JSON data from IPFS using the configured gateway.
  *
- * Gateway is `https://ipfs.centrifuge.io/ipfs/` by default (matches the registry
+ * Gateway is `https://centrifuge-files.mypinata.cloud/ipfs/` by default (matches the registry
  * fetcher) and can be overridden via the `IPFS_GATEWAY` env var. A trailing slash
  * is enforced.
  *


### PR DESCRIPTION
## Summary
- Switch all hardcoded `ipfs.centrifuge.io` references to the Pinata dedicated gateway (`centrifuge-files.mypinata.cloud`)
- CIDs unchanged, only the host changes, so content stays identical
- Touches: `src/helpers/ipfs.ts` (DEFAULT_IPFS_GATEWAY + JSDoc), `scripts/fetch-registry.mjs` (IPFS_GATEWAY default), `src/chains.ts` (chainIcons URLs), and `REGISTRY_URL` in the 4 mainnet env files

Closes #466

## Test plan
- [x] `pnpm update-registry` fetches via the new gateway
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck` (clean)