### PR TITLE
fix(smoke): skip escrow check for pools not activated on spoke

### DIFF
--- a/test/smoke/checks/escrow.mjs
+++ b/test/smoke/checks/escrow.mjs
@@ -7,6 +7,10 @@ const BALANCE_SHEET_ABI = parseAbi([
   "function escrow(uint64 poolId) view returns (address)",
 ]);
 
+const SPOKE_ABI = parseAbi([
+  "function isPoolActive(uint64 poolId) view returns (bool)",
+]);
+
 const ESCROWS_QUERY = `
   query Escrows($limit: Int!, $after: String) {
     escrows(limit: $limit, after: $after, orderBy: "poolId", orderDirection: "asc") {
@@ -61,6 +65,24 @@ export async function runSmoke(ctx) {
     if (!chain?.deployment.balanceSheet) {
       skipped += 1;
       continue;
+    }
+
+    // Skip pools not activated on the current spoke. BalanceSheet.escrow() is a
+    // pure CREATE2 precompute (IPoolEscrowProvider does not check deployment),
+    // so unmigrated pools return a phantom address with no code. Comparing
+    // against it is a false signal. See specs/escrow.md skip conditions.
+    if (chain.deployment.spoke) {
+      const active = await chain.client.readContract({
+        address: chain.deployment.spoke,
+        abi: SPOKE_ABI,
+        functionName: "isPoolActive",
+        args: [poolIdArg(escrow.poolId)],
+        blockNumber: ctx.atBlock,
+      });
+      if (!active) {
+        skipped += 1;
+        continue;
+      }
     }
 
     const chainLabel = escrow.blockchain?.name ?? chain.chainName;

--- a/test/unit/smoke-escrow.test.ts
+++ b/test/unit/smoke-escrow.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../smoke/lib/context.mjs", () => ({
+  resolveEntityChain: vi.fn(),
+}));
+
+import { runSmoke } from "../smoke/checks/escrow.mjs";
+import { resolveEntityChain } from "../smoke/lib/context.mjs";
+
+const mockedResolve = vi.mocked(resolveEntityChain);
+
+type SmokeCtx = Parameters<typeof runSmoke>[0];
+
+interface MockChainOpts {
+  balanceSheet?: string | null;
+  spoke?: string | null;
+  chainName?: string;
+  isPoolActive?: boolean;
+  escrowAddress?: string;
+}
+
+function mockChain(opts: MockChainOpts) {
+  return {
+    chainId: 1,
+    chainName: opts.chainName ?? "ethereum",
+    centrifugeId: "1",
+    deployment: {
+      balanceSheet: opts.balanceSheet === undefined ? "0xBAL0000000000000000000000000000000000000" : opts.balanceSheet,
+      spoke: opts.spoke === undefined ? "0xSPOKE000000000000000000000000000000000000" : opts.spoke,
+    },
+    client: {
+      readContract: vi.fn(async ({ functionName }: { functionName: string }) => {
+        if (functionName === "isPoolActive") return opts.isPoolActive ?? true;
+        if (functionName === "escrow") return opts.escrowAddress ?? "0x0000000000000000000000000000000000000000";
+        throw new Error(`unexpected readContract call: ${functionName}`);
+      }),
+    },
+  } as never;
+}
+
+interface FakeEscrow {
+  address: string;
+  poolId: string;
+  centrifugeId: string;
+  createdAtBlock: number;
+  blockchain?: { id: string; name: string };
+}
+
+function mockCtx(escrows: FakeEscrow[]): SmokeCtx {
+  return {
+    paginate: vi.fn().mockResolvedValue(escrows),
+    filters: {},
+    sampleCandidates: vi.fn((cands: FakeEscrow[]) => cands),
+    atBlock: undefined,
+    mismatch: vi.fn((m: Record<string, unknown>) => ({ smokeId: "escrow", ...m })),
+  } as unknown as SmokeCtx;
+}
+
+describe("escrow smoke - isPoolActive skip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips pools not activated on the spoke", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0xAAAa000000000000000000000000000000000000", poolId: "100", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+    ];
+    mockedResolve.mockResolvedValue(mockChain({ isPoolActive: false }));
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("compares active pools with matching address", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0xAAAa000000000000000000000000000000000000", poolId: "100", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+    ];
+    mockedResolve.mockResolvedValue(
+      mockChain({ isPoolActive: true, escrowAddress: "0xAAAa000000000000000000000000000000000000" })
+    );
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("records mismatch for active pool with wrong address", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0xBBBb000000000000000000000000000000000000", poolId: "100", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+    ];
+    mockedResolve.mockResolvedValue(
+      mockChain({ isPoolActive: true, escrowAddress: "0xCCCc000000000000000000000000000000000000" })
+    );
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      field: "address",
+      indexed: "0xbbbb000000000000000000000000000000000000",
+      onchain: "0xcccc000000000000000000000000000000000000",
+    });
+  });
+
+  it("still compares when spoke address is missing (no skip)", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0xAAAa000000000000000000000000000000000000", poolId: "100", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+    ];
+    mockedResolve.mockResolvedValue(
+      mockChain({ spoke: null, escrowAddress: "0xAAAa000000000000000000000000000000000000" })
+    );
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("skips when balanceSheet is missing", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0xAAAa000000000000000000000000000000000000", poolId: "100", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+    ];
+    mockedResolve.mockResolvedValue(mockChain({ balanceSheet: null, isPoolActive: true }));
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("handles same pool on two chains: skips inactive, compares active", async () => {
+    const escrows: FakeEscrow[] = [
+      { address: "0x34b7000000000000000000000000000000000000", poolId: "9001", centrifugeId: "1", createdAtBlock: 100, blockchain: { id: "1", name: "ethereum" } },
+      { address: "0x1114000000000000000000000000000000000000", poolId: "9001", centrifugeId: "2", createdAtBlock: 200, blockchain: { id: "8453", name: "base" } },
+    ];
+
+    mockedResolve.mockImplementation((async (_ctx: unknown, row: FakeEscrow) => {
+      if (row.centrifugeId === "1") {
+        return mockChain({ isPoolActive: false, chainName: "ethereum" });
+      }
+      return mockChain({
+        isPoolActive: true,
+        escrowAddress: "0x1114000000000000000000000000000000000000",
+        chainName: "base",
+      });
+    }) as never);
+
+    const ctx = mockCtx(escrows);
+
+    const result = await runSmoke(ctx);
+
+    expect(result.checked).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.mismatches).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- The escrow smoke check compared indexed escrow addresses against `BalanceSheet.escrow(poolId)` for every pool, including pools never activated on the v3.1 spoke.
- `BalanceSheet.escrow()` is a pure CREATE2 precompute. `IPoolEscrowProvider.escrow()` explicitly does not check whether the escrow was deployed, so pools without a v3.1 escrow return a deterministic address with no code. This produced 4 false mismatches on ethereum.
- Adds the "Pool not yet activated on spoke" skip condition already documented in `specs/escrow.md` but never implemented in `checks/escrow.mjs`. The check now calls `isPoolActive(poolId)` on the current spoke before comparing.

## Root cause analysis

### Why the pools exist in GraphQL but are not on the v3.1 spoke

The GraphQL `Pool` entity is created by `hubRegistry:NewPool`, a hub-side event (`hubRegistryHandlers.ts`). Pool existence and `isActive` on the hub are independent of spoke-side migration. Spoke migration is per-chain: a pool is activated on a given chain's spoke via `Spoke.addPool()`, which is also the only caller of `PoolEscrowFactory.newEscrow()` (`Spoke.sol:184`). No `addPool` means no v3.1 escrow on that chain.

### On-chain evidence (ethereum v3.1, spoke `0xEC3582fc...`, factory `0x5187A505...`)

Enumerated every `AddPool` event on the v3.1 ethereum spoke from its deploy block (24319323) to head. Activated hub-1 pools: 2, 3, 4, 5, 6, 7, 8, 11, 15, 16, 17. Pools 1, 9, 10, 12 are absent.

Three independent confirmations for each of the 4 pools:
- `isPoolActive(poolId)` on the v3.1 spoke returns `false` (control pool 2 returns `true`).
- Zero bytecode at the 4 reported "onchain" escrow addresses (`0x4521E4bf...`, `0x1114F607...`, `0x1e48F1B5...`, `0xc6583b23...`). Since `DeployPoolEscrow` is only emitted inside `newEscrow()` (which deploys the contract), no v3.1 event ever existed for these pools.
- The indexed addresses are the real v3 escrows: `DeployPoolEscrow` events verified on-chain at the indexed blocks (22931643, 23397777, 24024233), with live bytecode at each address.

### Migration is per-chain and partial

| Pool | ethereum v3.1 spoke | base v3.1 spoke |
|------|--------------------|-----------------|
| 1 (Janus Henderson Anemoy Treasury) | not active | not active |
| 9 (JH Anemoy S&P 500) | not active | active |
| 10 (unnamed) | not active | not active |
| 12 (SPXA deRWA) | not active | active |

Pools 9 and 12 migrated on base but not ethereum. Pools 1 and 10 are not migrated on either chain checked. The earlier "never migrated" framing is correct only at the ethereum scope.

The fix correctly handles the cross-chain case: `resolveEntityChain` routes by `centrifugeId`, so pool 9's ethereum row is checked against ethereum's spoke (inactive, skip) while pool 9's base row is checked against base's spoke (active, compare, match). Verified on base: `isPoolActive = true`, `BalanceSheet.escrow(9) = 0x1114F607...` with 10625 bytes of code deployed, matching the indexed address.

### Conclusion

Not an indexer gap and not the Ponder factory cache bug (#2271): there was no v3.1 `DeployPoolEscrow` event on ethereum to miss. The indexer correctly stores the last actually-deployed (v3) escrow. The smoke check was comparing against an undeployed CREATE2 precompute for pools the spec already says to skip.

## Test plan

- [x] `npx vitest run test/unit/smoke-escrow.test.ts` -> 6 tests pass (skip, compare, mismatch, missing spoke, missing balanceSheet, cross-chain)
- [x] `node test/smoke/cli.mjs escrow --chain ethereum --sample 0` -> 59 checked, 4 skipped, 0 mismatches (was 4 mismatches)
- [x] `node test/smoke/cli.mjs escrow --sample 0` -> 59 checked, 4 skipped, 0 mismatches
- [x] Linter clean on `test/smoke/checks/escrow.mjs` and `test/unit/smoke-escrow.test.ts`
- [x] Typecheck clean

## Follow-up (ops, not code)

Pools 1 and 10 are not migrated to v3.1 on any chain checked. Worth confirming that is expected and not a stalled migration.